### PR TITLE
Tasks and Node Tasks

### DIFF
--- a/lib/moana/messages.ex
+++ b/lib/moana/messages.ex
@@ -1,0 +1,240 @@
+defmodule Moana.Messages do
+  @moduledoc """
+  The Messages context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Moana.Repo
+
+  alias Moana.Messages.Task
+  alias Moana.Messages.NodeTask
+  alias Moana.Storage.Node
+
+  @doc """
+  Returns the list of tasks.
+
+  ## Examples
+
+      iex> list_tasks()
+      [%Task{}, ...]
+
+  """
+  def list_tasks do
+    Repo.all(Task)
+  end
+
+  @doc """
+  Returns the list of tasks.
+
+  ## Examples
+
+      iex> list_tasks()
+      [%Task{}, ...]
+
+  """
+  def list_tasks(cluster_id) do
+    Repo.all(from t in Task,
+      join: nt in NodeTask, on: t.id == nt.task_id,
+      join: n in Node, on: nt.node_id == n.id,
+      where: t.cluster_id == ^cluster_id,
+      preload: [nodetasks: {nt, nodes: n}]
+    )
+  end
+
+  @doc """
+  Gets a single task.
+
+  Raises `Ecto.NoResultsError` if the Task does not exist.
+
+  ## Examples
+
+      iex> get_task!(123)
+      %Task{}
+
+      iex> get_task!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_task!(id) do
+    Repo.get!(
+    (
+      from t in Task,
+      join: nt in NodeTask, on: t.id == nt.task_id,
+      join: n in Node, on: nt.node_id == n.id,
+      preload: [nodetasks: {nt, nodes: n}]
+    ),
+      id
+    )
+  end
+
+  @doc """
+  Creates a task.
+
+  ## Examples
+
+      iex> create_task(%{field: value})
+      {:ok, %Task{}}
+
+      iex> create_task(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_task(attrs \\ %{}) do
+    %Task{}
+    |> Task.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a task.
+
+  ## Examples
+
+      iex> update_task(task, %{field: new_value})
+      {:ok, %Task{}}
+
+      iex> update_task(task, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_task(%Task{} = task, attrs) do
+    task
+    |> Task.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a task.
+
+  ## Examples
+
+      iex> delete_task(task)
+      {:ok, %Task{}}
+
+      iex> delete_task(task)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_task(%Task{} = task) do
+    Repo.delete(task)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking task changes.
+
+  ## Examples
+
+      iex> change_task(task)
+      %Ecto.Changeset{source: %Task{}}
+
+  """
+  def change_task(%Task{} = task) do
+    Task.changeset(task, %{})
+  end
+
+  @doc """
+  Returns the list of nodetasks.
+
+  ## Examples
+
+      iex> list_nodetasks()
+      [%NodeTask{}, ...]
+
+  """
+  def list_nodetasks(node_id) do
+    Repo.all(from nt in NodeTask,
+      join: t in Task, on: t.id == nt.task_id,
+      where: nt.node_id == ^node_id,
+      preload: [:tasks]
+    )
+  end
+
+  @doc """
+  Gets a single node_task.
+
+  Raises `Ecto.NoResultsError` if the Node task does not exist.
+
+  ## Examples
+
+      iex> get_node_task!(123)
+      %NodeTask{}
+
+      iex> get_node_task!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_node_task!(id) do
+    Repo.get!(
+    (
+      from nt in NodeTask,
+      join: t in Task, on: t.id == nt.task_id,
+      preload: [:tasks]
+    ),
+      id)
+  end
+
+  @doc """
+  Creates a node_task.
+
+  ## Examples
+
+      iex> create_node_task(%{field: value})
+      {:ok, %NodeTask{}}
+
+      iex> create_node_task(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_node_task(attrs \\ %{}) do
+    %NodeTask{}
+    |> NodeTask.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a node_task.
+
+  ## Examples
+
+      iex> update_node_task(node_task, %{field: new_value})
+      {:ok, %NodeTask{}}
+
+      iex> update_node_task(node_task, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_node_task(%NodeTask{} = node_task, attrs) do
+    node_task
+    |> NodeTask.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a node_task.
+
+  ## Examples
+
+      iex> delete_node_task(node_task)
+      {:ok, %NodeTask{}}
+
+      iex> delete_node_task(node_task)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_node_task(%NodeTask{} = node_task) do
+    Repo.delete(node_task)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking node_task changes.
+
+  ## Examples
+
+      iex> change_node_task(node_task)
+      %Ecto.Changeset{source: %NodeTask{}}
+
+  """
+  def change_node_task(%NodeTask{} = node_task) do
+    NodeTask.changeset(node_task, %{})
+  end
+end

--- a/lib/moana/messages/node_task.ex
+++ b/lib/moana/messages/node_task.ex
@@ -1,0 +1,24 @@
+defmodule Moana.Messages.NodeTask do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "nodetasks" do
+    field :response, :string
+    field :state, :string
+    belongs_to :tasks, Moana.Messages.Task, [foreign_key: :task_id]
+    belongs_to :nodes, Moana.Storage.Node, [foreign_key: :node_id]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(node_task, attrs) do
+    node_task
+    |> cast(attrs, [:response, :state, :task_id, :node_id])
+    |> validate_required([:state, :task_id, :node_id])
+    |> foreign_key_constraint(:task_id)
+    |> foreign_key_constraint(:node_id)
+  end
+end

--- a/lib/moana/messages/task.ex
+++ b/lib/moana/messages/task.ex
@@ -1,0 +1,25 @@
+defmodule Moana.Messages.Task do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "tasks" do
+    field :data, :string
+    field :state, :string
+    field :type, :string
+    has_many :nodetasks, Moana.Messages.NodeTask, foreign_key: :task_id
+    belongs_to :clusters, Moana.Storage.Cluster, [foreign_key: :cluster_id]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(task, attrs) do
+    task
+    |> cast(attrs, [:type, :data, :state, :cluster_id])
+    |> validate_required([:type, :data, :state, :cluster_id])
+    |> foreign_key_constraint(:task_id)
+    |> foreign_key_constraint(:cluster_id)
+  end
+end

--- a/lib/moana/storage/cluster.ex
+++ b/lib/moana/storage/cluster.ex
@@ -7,6 +7,7 @@ defmodule Moana.Storage.Cluster do
   schema "clusters" do
     field :name, :string
     has_many :nodes, Moana.Storage.Node, foreign_key: :cluster_id
+    has_many :tasks, Moana.Messages.Task, foreign_key: :cluster_id
 
     timestamps()
   end

--- a/lib/moana/storage/node.ex
+++ b/lib/moana/storage/node.ex
@@ -7,6 +7,7 @@ defmodule Moana.Storage.Node do
   schema "nodes" do
     field :hostname, :string
     belongs_to :clusters, Moana.Storage.Cluster, [foreign_key: :cluster_id]
+    has_many :nodetasks, Moana.Messages.NodeTask, foreign_key: :node_id
 
     timestamps()
   end
@@ -17,6 +18,7 @@ defmodule Moana.Storage.Node do
     |> cast(attrs, [:hostname, :cluster_id])
     |> validate_required([:hostname, :cluster_id])
     |> foreign_key_constraint(:cluster_id)
+    |> foreign_key_constraint(:node_id)
     |> unique_constraint(:hostname, name: :nodes_hostname_cluster_id_index)
   end
 end

--- a/lib/moana/volume_tasks.ex
+++ b/lib/moana/volume_tasks.ex
@@ -1,0 +1,17 @@
+defmodule Moana.VolumeTasks do
+
+  def valid(:volume_create, params) do
+    # TODO: Validate each argument for Volume Create Request
+    true
+  end
+
+  def get_nodes(:volume_create, params) do
+    Enum.map(Map.fetch!(params, "bricks"), fn brick ->
+      Map.fetch!(brick, "node_id")
+    end)
+  end
+
+  def on_success(:volume_create, params) do
+    # TODO: Insert to Volumes, subvols and bricks table
+  end
+end

--- a/lib/moana_web/controllers/node_task_controller.ex
+++ b/lib/moana_web/controllers/node_task_controller.ex
@@ -1,0 +1,35 @@
+defmodule MoanaWeb.NodeTaskController do
+  use MoanaWeb, :controller
+
+  alias Moana.Messages
+  alias Moana.Messages.Task
+  alias Moana.Messages.NodeTask
+
+  action_fallback MoanaWeb.FallbackController
+
+  def index(conn, %{"node_id" => node_id}) do
+    node_tasks = Messages.list_nodetasks(node_id)
+    render(conn, "index.json", node_tasks: node_tasks)
+  end
+
+  def show(conn, %{"id" => id}) do
+    node_task = Messages.get_node_task!(id)
+    render(conn, "show.json", node_task: node_task)
+  end
+
+  def update(conn, %{"id" => id, "task" => task_params}) do
+    node_task = Messages.get_node_task!(id)
+
+    with {:ok, %NodeTask{} = node_task} <- Messages.update_node_task(node_task, task_params) do
+      render(conn, "show.json", node_task: node_task)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    node_task = Messages.get_node_task!(id)
+
+    with {:ok, %NodeTask{}} <- Messages.delete_node_task(node_task) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/moana_web/controllers/task_controller.ex
+++ b/lib/moana_web/controllers/task_controller.ex
@@ -1,0 +1,35 @@
+defmodule MoanaWeb.TaskController do
+  use MoanaWeb, :controller
+
+  alias Moana.Messages
+  alias Moana.Messages.Task
+  alias Moana.Messages.NodeTask
+
+  action_fallback MoanaWeb.FallbackController
+
+  def index(conn, %{"cluster_id" => cluster_id}) do
+    tasks = Messages.list_tasks(cluster_id)
+    render(conn, "index.json", tasks: tasks)
+  end
+
+  def show(conn, %{"id" => id}) do
+    task = Messages.get_task!(id)
+    render(conn, "show.json", task: task)
+  end
+
+  def update(conn, %{"id" => id, "task" => task_params}) do
+    task = Messages.get_task!(id)
+
+    with {:ok, %Task{} = task} <- Messages.update_task(task, task_params) do
+      render(conn, "show.json", task: task)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    task = Messages.get_task!(id)
+
+    with {:ok, %Task{}} <- Messages.delete_task(task) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/moana_web/controllers/volume_controller.ex
+++ b/lib/moana_web/controllers/volume_controller.ex
@@ -1,0 +1,60 @@
+defmodule MoanaWeb.VolumeController do
+  use MoanaWeb, :controller
+  import Jason
+
+  alias Moana.Messages
+  alias Moana.Messages.Task
+  alias Moana.Messages.NodeTask
+  alias Moana.VolumeTasks
+
+  action_fallback MoanaWeb.FallbackController
+
+  def index(conn, %{"cluster_id" => cluster_id}) do
+    render(conn, "index.json", volumes: [])
+  end
+
+  def create(conn, %{"volume" => volume_params, "cluster_id" => cluster_id}) do
+    # TODO: Duplicate Volume check
+    node_ids = VolumeTasks.get_nodes(:volume_create, volume_params)
+
+    # TODO: Handle error
+    {:ok, encoded} = Jason.encode(volume_params)
+
+    task_params = %{
+      state: "Creating",
+      cluster_id: cluster_id,
+      type: "VOLUME_CREATE",
+      data: encoded
+    }
+    IO.inspect node_ids
+    with {:ok, %Task{} = task} <- Messages.create_task(task_params) do
+      # TODO: Handle error while adding node tasks
+      Enum.map(node_ids, fn node_id ->
+        Messages.create_node_task(
+          %{
+            state: "Pending",
+            task_id: task.id,
+            node_id: node_id
+          }
+        )
+      end)
+
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.cluster_task_path(conn, :show, cluster_id, task))
+      |> render(MoanaWeb.TaskView, "showid.json", task: task)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    render(conn, "show.json", volume: %{})
+  end
+
+  def update(conn, %{"id" => id, "task" => task_params}) do
+    # TODO: What details can be updated?
+  end
+
+  def delete(conn, %{"id" => id}) do
+    # TODO: Volume Delete request
+  end
+end

--- a/lib/moana_web/router.ex
+++ b/lib/moana_web/router.ex
@@ -10,6 +10,10 @@ defmodule MoanaWeb.Router do
 
     resources "/clusters", ClusterController, except: [:new, :edit] do
       resources "/nodes", NodeController, except: [:new, :edit]
+      resources "/tasks", TaskController, except: [:new, :edit, :create]
+      resources "/volumes", VolumeController, except: [:new, :edit]
     end
+
+    resources "/nodes/:node_id/tasks", NodeTaskController, except: [:new, :edit, :create]
   end
 end

--- a/lib/moana_web/views/node_task_view.ex
+++ b/lib/moana_web/views/node_task_view.ex
@@ -1,0 +1,29 @@
+defmodule MoanaWeb.NodeTaskView do
+  use MoanaWeb, :view
+  alias MoanaWeb.NodeTaskView
+
+  def render("index.json", %{node_tasks: node_tasks}) do
+    %{data: render_many(node_tasks, NodeTaskView, "nodetask.json")}
+  end
+
+  def render("show.json", %{node_task: node_task}) do
+    %{data: render_one(node_task, NodeTaskView, "nodetask.json")}
+  end
+
+  def render("nodetask.json", %{node_task: node_task}) do
+    %{id: node_task.id,
+      state: node_task.state,
+      task: render_one(node_task.tasks, NodeTaskView, "task.json", as: :task),
+      node_id: node_task.node_id
+    }
+  end
+
+  def render("task.json", %{task: task}) do
+    %{
+      id: task.id,
+      state: task.state,
+      data: task.data,
+      type: task.type
+    }
+  end
+end

--- a/lib/moana_web/views/task_view.ex
+++ b/lib/moana_web/views/task_view.ex
@@ -1,0 +1,42 @@
+defmodule MoanaWeb.TaskView do
+  use MoanaWeb, :view
+  alias MoanaWeb.TaskView
+
+  def render("index.json", %{tasks: tasks}) do
+    %{data: render_many(tasks, TaskView, "task.json")}
+  end
+
+  def render("show.json", %{task: task}) do
+    %{data: render_one(task, TaskView, "task.json")}
+  end
+
+  def render("showid.json", %{task: task}) do
+    %{
+      id: task.id
+    }
+  end
+
+  def render("task.json", %{task: task}) do
+    %{id: task.id,
+      state: task.state,
+      type: task.type,
+      nodetasks: render_many(task.nodetasks, TaskView, "nodetask.json", as: :nodetask),
+      data: task.data
+    }
+  end
+
+  def render("nodetask.json", %{nodetask: nodetask}) do
+    %{
+      id: nodetask.id,
+      state: nodetask.state,
+      node: render_one(nodetask.nodes, TaskView, "node.json", as: :node)
+    }
+  end
+
+  def render("node.json", %{node: node}) do
+    %{
+      id: node.id,
+      hostname: node.hostname
+    }
+  end
+end

--- a/lib/moana_web/views/volume_view.ex
+++ b/lib/moana_web/views/volume_view.ex
@@ -1,0 +1,17 @@
+defmodule MoanaWeb.VolumeView do
+  use MoanaWeb, :view
+  alias MoanaWeb.VolumeView
+
+  def render("index.json", %{volumes: volumes}) do
+    %{data: render_many(volumes, VolumeView, "volume.json")}
+  end
+
+  def render("show.json", %{volume: volume}) do
+    %{data: render_one(volume, VolumeView, "volume.json")}
+  end
+
+  def render("volume.json", %{volume: volume}) do
+    %{id: volume.id,
+      name: volume.name}
+  end
+end

--- a/priv/repo/migrations/20200411054041_create_tasks.exs
+++ b/priv/repo/migrations/20200411054041_create_tasks.exs
@@ -1,0 +1,16 @@
+defmodule Moana.Repo.Migrations.CreateTasks do
+  use Ecto.Migration
+
+  def change do
+    create table(:tasks, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :type, :string
+      add :data, :string
+      add :state, :string
+      add :cluster_id, references(:clusters, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20200411054106_create_nodetasks.exs
+++ b/priv/repo/migrations/20200411054106_create_nodetasks.exs
@@ -1,0 +1,18 @@
+defmodule Moana.Repo.Migrations.CreateNodetasks do
+  use Ecto.Migration
+
+  def change do
+    create table(:nodetasks, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :response, :string
+      add :state, :string
+      add :task_id, references(:tasks, on_delete: :nothing, type: :binary_id)
+      add :node_id, references(:nodes, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:nodetasks, [:task_id])
+    create index(:nodetasks, [:node_id])
+  end
+end


### PR DESCRIPTION
Each action will add entry to "tasks" table and tasks for
participating nodes in "nodetasks" table.

For example, Volume Create request will be validated and
added to tasks table and nodetasks table.

Node agent can update the node task status for each stages.

```
Pending -> Received -> Success|Failure
```

```
GET     /api/v1/clusters/:cluster_id/tasks
GET     /api/v1/clusters/:cluster_id/tasks/:id
PATCH   /api/v1/clusters/:cluster_id/tasks/:id
PUT     /api/v1/clusters/:cluster_id/tasks/:id
DELETE  /api/v1/clusters/:cluster_id/tasks/:id
POST    /api/v1/clusters/:cluster_id/volumes
GET     /api/v1/nodes/:node_id/tasks
GET     /api/v1/nodes/:node_id/tasks/:id
PATCH   /api/v1/nodes/:node_id/tasks/:id
PUT     /api/v1/nodes/:node_id/tasks/:id
DELETE  /api/v1/nodes/:node_id/tasks/:id
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>