### PR TITLE
Use Nodes details with Cluster List

### DIFF
--- a/lib/moana/storage.ex
+++ b/lib/moana/storage.ex
@@ -7,6 +7,7 @@ defmodule Moana.Storage do
   alias Moana.Repo
 
   alias Moana.Storage.Cluster
+  alias Moana.Storage.Node
 
   @doc """
   Returns the list of clusters.
@@ -18,7 +19,10 @@ defmodule Moana.Storage do
 
   """
   def list_clusters do
-    Repo.all(Cluster)
+    Repo.all(from c in Cluster,
+      left_join: n in Node, on: c.id == n.cluster_id,
+      preload: [:nodes]
+    )
   end
 
   @doc """
@@ -35,7 +39,14 @@ defmodule Moana.Storage do
       ** (Ecto.NoResultsError)
 
   """
-  def get_cluster!(id), do: Repo.get!(Cluster, id)
+  def get_cluster!(id) do
+    Repo.get!((
+      from c in Cluster,
+      left_join: n in Node, on: c.id == n.cluster_id,
+      preload: [:nodes]
+    ),
+      id)
+  end
 
   @doc """
   Creates a cluster.
@@ -101,8 +112,6 @@ defmodule Moana.Storage do
   def change_cluster(%Cluster{} = cluster) do
     Cluster.changeset(cluster, %{})
   end
-
-  alias Moana.Storage.Node
 
   @doc """
   Returns the list of nodes.

--- a/lib/moana_web/controllers/cluster_controller.ex
+++ b/lib/moana_web/controllers/cluster_controller.ex
@@ -16,7 +16,7 @@ defmodule MoanaWeb.ClusterController do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.cluster_path(conn, :show, cluster))
-      |> render("show.json", cluster: cluster)
+      |> render("show.json", cluster: Map.put(cluster, :nodes, []))
     end
   end
 

--- a/lib/moana_web/views/cluster_view.ex
+++ b/lib/moana_web/views/cluster_view.ex
@@ -1,6 +1,7 @@
 defmodule MoanaWeb.ClusterView do
   use MoanaWeb, :view
   alias MoanaWeb.ClusterView
+  alias MoanaWeb.NodeView
 
   def render("index.json", %{clusters: clusters}) do
     %{data: render_many(clusters, ClusterView, "cluster.json")}
@@ -11,7 +12,10 @@ defmodule MoanaWeb.ClusterView do
   end
 
   def render("cluster.json", %{cluster: cluster}) do
-    %{id: cluster.id,
-      name: cluster.name}
+    %{
+      id: cluster.id,
+      name: cluster.name,
+      nodes: render_many(cluster.nodes, NodeView, "node.json", as: :node)
+    }
   end
 end


### PR DESCRIPTION
Use Left outer Join with clusters and nodes table to show
nodes details in clusters list.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>