### PR TITLE
Set default Cluster

### DIFF
--- a/cli/src/clusters.cr
+++ b/cli/src/clusters.cr
@@ -7,15 +7,29 @@ require "./helpers"
 
 def show_clusters(gflags, args)
   cluster_data = Array(Cluster).from_json(save_and_get_clusters_list(gflags.moana_url))
-
+  default_cluster_id = default_cluster()
   if cluster_data
-    printf("%-36s  %-s\n", "ID", "Name")
+    printf(" %-36s  %-s\n", "ID", "Name")
   end
   cluster_data.each do |cluster|
     if args.name == "" || cluster.id == args.name || cluster.name == args.name
-      printf("%-36s  %-s\n", cluster.id, cluster.name)
+      pfx = " "
+      pfx = "*" if cluster.id == default_cluster_id
+      printf("%s%-36s  %-s\n", pfx, cluster.id, cluster.name)
     end
   end
+end
+
+def save_default_cluster(cluster_id)
+  filename = Path.home.join(".moana", "default_cluster")
+  File.write(filename, cluster_id)
+end
+
+def set_default_cluster(gflags, args)
+  cluster_id = cluster_id_from_name(args.name)
+  save_default_cluster(cluster_id)
+  puts "Default cluster set successfully.\n"
+  puts "Note: The default cluster details is stored locally in this node"
 end
 
 def create_cluster(gflags, args)
@@ -27,8 +41,13 @@ def create_cluster(gflags, args)
   )
   if response.status_code == 201
     save_and_get_clusters_list(gflags.moana_url)
+    default_cluster_id = default_cluster()
     puts "Cluster created successfully."
     puts "ID: #{Cluster.from_json(response.body).id}"
+    if default_cluster_id == ""
+      save_default_cluster(Cluster.from_json(response.body).id)
+      puts "\nSaved as default Cluster"
+    end
   else
     STDERR.puts response.status_code
   end
@@ -57,7 +76,13 @@ def delete_cluster(gflags, args)
   response = HTTP::Client.delete url
 
   if response.status_code == 204
+    default_cluster_id = default_cluster()
     save_and_get_clusters_list(gflags.moana_url)
+    # If the Cluster deleted is the default Cluster then
+    # reset default cluster.
+    if default_cluster_id == cluster_id
+      save_default_cluster("")
+    end
     puts "Cluster deleted successfully"
   elsif response.status_code == 404
     STDERR.puts "Invalid Cluster name"

--- a/cli/src/helpers.cr
+++ b/cli/src/helpers.cr
@@ -119,3 +119,12 @@ def save_and_get_clusters_list(base_url)
 
   content
 end
+
+def default_cluster
+  filename = Path.home.join(".moana", "default_cluster")
+  if File.exists?(filename)
+    File.read(filename)
+  else
+    ""
+  end
+end

--- a/moana-node/.gitignore
+++ b/moana-node/.gitignore
@@ -11,3 +11,4 @@ production.yml
 /bin/
 /node_modules
 /public/dist
+node.json


### PR DESCRIPTION
* On Cluster create, if no default cluster is set then set the
  created Cluster as default. Also show in the CLI response.
* Default cluster ID will be stored in `$HOME/.moana/default_cluster`.
  This will not be remembered in other nodes.
* Show `*` prefix for the default Cluster while showing the Cluster list
* Show help message to use this command while showing Cluster ID not
  specified(if cluster id is not set or that file is deleted)

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>