### PR TITLE
cli: Volume Options set/reset support

### DIFF
--- a/client/src/volumes.cr
+++ b/client/src/volumes.cr
@@ -93,29 +93,29 @@ module MoanaClient
       end
     end
 
-    def set_option(req : Hash(String, String))
-      url = "#{ctx.url}/api/v1/clusters/#{req.cluster_id}/volumes/#{@id}/options/set"
+    def set_options(req : Hash(String, String))
+      url = "#{@ctx.url}/api/v1/clusters/#{@cluster_id}/volumes/#{@id}/options/set"
       response = MoanaClient.http_post(
         url,
         req.to_json,
-        headers: MoanaClient.auth_header(ctx)
+        headers: MoanaClient.auth_header(@ctx)
       )
       if response.status_code == 200
-        MoanaTypes::Task.from_json(response.body)
+        MoanaTypes::Ok.from_json(response.body)
       else
         MoanaClient.error_response(response)
       end
     end
 
-    def reset_option(req : Array(String))
-      url = "#{ctx.url}/api/v1/clusters/#{req.cluster_id}/volumes/#{@id}/options/reset"
+    def reset_options(req : Array(String))
+      url = "#{@ctx.url}/api/v1/clusters/#{@cluster_id}/volumes/#{@id}/options/reset"
       response = MoanaClient.http_post(
         url,
         req.to_json,
-        headers: MoanaClient.auth_header(ctx)
+        headers: MoanaClient.auth_header(@ctx)
       )
       if response.status_code == 200
-        MoanaTypes::Task.from_json(response.body)
+        MoanaTypes::Ok.from_json(response.body)
       else
         MoanaClient.error_response(response)
       end

--- a/server/src/db/option.cr
+++ b/server/src/db/option.cr
@@ -23,7 +23,7 @@ module MoanaDB
        cluster_id UUID,
        volume_id  UUID,
        name       VARCHAR,
-       value      VARCHAR
+       value      VARCHAR,
        created_at TIMESTAMP,
        updated_at TIMESTAMP,
        PRIMARY KEY (volume_id, name)
@@ -75,10 +75,12 @@ module MoanaDB
   end
 
   def self.delete_option(volume_id : String, names : Array(String), conn = @@conn)
-    query = "DELETE FROM options WHERE volume_id = ? AND IN "
+    query = "DELETE FROM options WHERE volume_id = ? AND name IN "
 
-    values = [volume_id]
+    values = [] of String
     params = [] of DB::Any
+
+    params << volume_id
 
     names.each do |name|
       values << "?"

--- a/types/src/response.cr
+++ b/types/src/response.cr
@@ -158,4 +158,10 @@ module MoanaTypes
 
     property token = ""
   end
+
+  struct Ok
+    include JSON::Serializable
+
+    property ok = false
+  end
 end


### PR DESCRIPTION
* Set Volume option using `kadalu volume set <volname> <opt-name> <value>`
* Reset Volume option using `kadalu volume reset <volname> <opt-name>`
* Note: No validation added now, adds any options to the Volinfo
* Automatic notification to connected clients is also not available.
* Option names are different than GlusterFS options. The syntax is
  `[<template-name>].<xlator-name>.<option-name>`. For example
  `client.debug/io-stats.client-log-level` or `debug/io-stats.client-log-level`

Example:

Volume Set

```
$ kadalu volume set gvol1 debug/io-stats.client-log-level DEBUG
```

Download the Volfile again to see that Volume option is used in the
generated Volfile.

```
$ kadalu volfile get client -v 97a7546b-5ab5-45b0-9861-acd9b6097519 -o /root/gvol1.vol
```

Volume Reset

```
$ kadalu volume reset gvol1 debug/io-stats.client-log-level
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>