### PR TITLE
Container based deployment

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+ARG branch="series_0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV VIRTUAL_ENV=/kadalu
+ENV PATH="$VIRTUAL_ENV/bin:/opt/sbin:/opt/bin:$PATH"
+RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends python3 curl xfsprogs net-tools telnet wget e2fsprogs init \
+    python3-pip sqlite build-essential g++ python3-dev flex bison openssl libssl-dev libtirpc-dev liburcu-dev \
+    libfuse-dev libuuid1 python3-distutils uuid-dev acl-dev libtool automake autoconf git pkg-config \
+    python3-venv libffi-dev && \
+    git clone --depth 1 https://github.com/kadalu/glusterfs --branch ${branch} --single-branch glusterfs && \
+    (cd glusterfs && ./autogen.sh && ./configure --prefix=/opt && make install && cd ..)
+
+# Debugging, Comment the above line and
+# uncomment below line
+ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.35.1-alpine as crystal
+FROM crystallang/crystal:0.36.1-alpine as crystal
 
 WORKDIR /app
 COPY node ./node

--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -1,0 +1,61 @@
+FROM crystallang/crystal:0.35.1-alpine as crystal
+
+WORKDIR /app
+COPY node ./node
+COPY cli ./cli
+COPY types ./types
+COPY client ./client
+COPY volgen ./volgen
+
+RUN cd node && shards install --production
+RUN cd node && VERSION=${VERSION} shards build --static --release --stats --time
+
+RUN cd cli && shards install --production
+RUN cd cli && VERSION=${VERSION} shards build --static --release --stats --time
+
+FROM ubuntu:20.04 as prod
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
+COPY --from=kadalu-storage/builder:latest /opt /opt
+
+RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 init && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /kadalu/templates /kadalu/volfiles
+RUN mkdir -p /var/run/gluster /var/log/glusterfs
+
+RUN mkdir -p /var/lib/kadalu /var/run/kadalu /var/lib/kadalu/volfiles /var/log/kadalu
+COPY extra/kadalu-brick@.service /lib/systemd/system/
+COPY extra/kadalu-node.service /lib/systemd/system/
+COPY extra/kadalu-brick /usr/sbin/
+RUN chmod +x /usr/sbin/kadalu-brick
+COPY extra/entrypoint_node.sh /usr/sbin/entrypoint_node.sh
+RUN chmod +x /usr/sbin/entrypoint_node.sh
+
+COPY --from=crystal /app/node/bin/kadalu-node /usr/sbin/kadalu-node
+COPY --from=crystal /app/cli/bin/kadalu /usr/sbin/kadalu
+
+RUN systemctl enable kadalu-node
+
+ARG version="(unknown)"
+# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+ARG builddate="(unknown)"
+
+LABEL build-date="${builddate}"
+LABEL io.k8s.description="KaDalu Storage Node agent"
+LABEL name="kadalu-storage-node"
+LABEL Summary="KaDalu Storage"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/kadalu/kadalu"
+LABEL vendor="kadalu"
+LABEL version="${version}"
+
+ENTRYPOINT ["/usr/sbin/entrypoint_node.sh"]
+CMD ["/usr/sbin/init"]
+
+# Debugging, Comment the above line and
+# uncomment below line
+# ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,53 @@
+FROM crystallang/crystal:0.35.1-alpine as crystal
+
+WORKDIR /app
+COPY server ./server
+COPY cli ./cli
+COPY types ./types
+COPY client ./client
+COPY volgen ./volgen
+
+RUN apk add --update --no-cache --force-overwrite sqlite-dev sqlite-static
+RUN cd server && shards install --production
+RUN cd server && VERSION=${VERSION} shards build --static --release --stats --time
+
+RUN cd cli && shards install --production
+RUN cd cli && VERSION=${VERSION} shards build --static --release --stats --time
+
+FROM ubuntu:20.04 as prod
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends python3 xfsprogs init && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY extra/kadalu-server.service /lib/systemd/system/
+COPY extra/entrypoint_server.sh /usr/sbin/entrypoint_server.sh
+RUN chmod +x /usr/sbin/entrypoint_server.sh
+
+COPY --from=crystal /app/server/bin/kadalu-server /usr/sbin/kadalu-server
+COPY --from=crystal /app/cli/bin/kadalu /usr/sbin/kadalu
+
+RUN systemctl enable kadalu-server
+
+ARG version="(unknown)"
+# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+ARG builddate="(unknown)"
+
+LABEL build-date="${builddate}"
+LABEL io.k8s.description="KaDalu Storage Server"
+LABEL name="kadalu-storage-server"
+LABEL Summary="KaDalu Storage Server"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/kadalu/kadalu"
+LABEL vendor="kadalu"
+LABEL version="${version}"
+
+ENTRYPOINT ["/usr/sbin/entrypoint_server.sh"]
+CMD ["/usr/sbin/init"]
+
+# Debugging, Comment the above line and
+# uncomment below line
+# ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.35.1-alpine as crystal
+FROM crystallang/crystal:0.36.1-alpine as crystal
 
 WORKDIR /app
 COPY server ./server

--- a/build_amd64_static.sh
+++ b/build_amd64_static.sh
@@ -17,4 +17,4 @@ VERSION=${VERSION} time -v shards build --static --release --stats --time
 mv bin/kadalu bin/kadalu-amd64
 "
 
-docker run --rm -it -v $PWD:/workspace -w /workspace crystallang/crystal:0.35.1-alpine /bin/sh -c "$CMDS"
+docker run --rm -it -v $PWD:/workspace -w /workspace crystallang/crystal:0.36.1-alpine /bin/sh -c "$CMDS"

--- a/client/shard.yml
+++ b/client/shard.yml
@@ -9,8 +9,6 @@ description: |
 
 license: Apache-2.0
 
-crystal: 0.35.1
-
 dependencies:
   moana_types:
     path: ../types

--- a/container-README.md
+++ b/container-README.md
@@ -31,7 +31,15 @@ docker network create kadalu
 Run one instance of `kadalu-storage/server` container and spawn multiple instance of `kadalu-storage/node` containers as required.
 
 ```
-docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name kadalu-control --network kadalu kadalu-storage/server
+docker run -d \
+    -v /sys/fs/cgroup/:/sys/fs/cgroup:ro \
+    --cap-add SYS_ADMIN \
+    --name kadalu-control \
+    -v /root/.kadalu/data-kadalu-control:/var/lib/kadalu \
+    -v /root/.kadalu/data-kadalu-control-config:/root/.kadalu \
+    --network kadalu \
+    --hostname kadalu-control
+    kadalu-storage/server
 ```
 
 Login and check if `kadalu-server` is running
@@ -53,8 +61,22 @@ Mar 05 08:01:45 e044bf61ea76 kadalu-server[34]: [development] Kemal is ready to 
 ```
 
 ```
-docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name node1 --network kadalu --hostname node1.kadalu kadalu-storage/node
-docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name node2 --network kadalu --hostname node2.kadalu kadalu-storage/node
+docker run -d \
+    -v /sys/fs/cgroup/:/sys/fs/cgroup:ro \
+    -v /Users/aravinda/kadalu-data/data-node1:/var/lib/kadalu \
+    --cap-add SYS_ADMIN \
+    --name node1 \
+    --network kadalu \
+    --hostname node1.kadalu \
+    kadalu-storage/node
+docker run -d \
+    -v /sys/fs/cgroup/:/sys/fs/cgroup:ro \
+    -v /Users/aravinda/kadalu-data/data-node2:/var/lib/kadalu \
+    --cap-add SYS_ADMIN \
+    --name node2 \
+    --network kadalu \
+    --hostname node2.kadalu \
+    kadalu-storage/node
 ```
 
 Login to check if `kadalu-node` service is running
@@ -163,8 +185,6 @@ c576818e-8c20-48c5-b92b-603a1aa37e11  gvol1           Distribute      Started
 
 ## TODO:
 
-* Add Volumes for `/var/lib/kadalu` for each Node containers
-* Add Volume for `kadalu-storage/server`(For Sqlite db and other things)
 * Set the required environment variables
 * How to communicate between containers(Self-heal daemon requires to connect to other storage nodes, kadalu-node agent needs to connect to Kadalu Server/Control plane)
 * Access brick directories inside `kadalu-storage/node` container(Dynamic access when new brick added)

--- a/container-README.md
+++ b/container-README.md
@@ -1,0 +1,173 @@
+# Kadalu Storage Management
+
+## Build Containers
+
+Builder base
+
+```
+docker build . --tag docker.io/kadalu-storage/builder -f Dockerfile.builder
+```
+
+Build node container
+
+```
+docker build . --tag docker.io/kadalu-storage/node -f Dockerfile.node
+```
+
+Build Server container
+
+```
+docker build . --tag docker.io/kadalu-storage/server -f Dockerfile.server
+```
+
+## Usage
+
+Create Kadalu network
+
+```
+docker network create kadalu
+```
+
+Run one instance of `kadalu-storage/server` container and spawn multiple instance of `kadalu-storage/node` containers as required.
+
+```
+docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name kadalu-control --network kadalu kadalu-storage/server
+```
+
+Login and check if `kadalu-server` is running
+
+```
+docker exec -it kadalu-control /bin/bash
+root@e044bf61ea76:/# systemctl status kadalu-server
+● kadalu-server.service - Kadalu Storage Server
+     Loaded: loaded (/lib/systemd/system/kadalu-server.service; enabled; vendor preset: enabled)
+     Active: active (running) since Fri 2021-03-05 08:01:45 UTC; 11min ago
+   Main PID: 34 (kadalu-server)
+      Tasks: 2 (limit: 2227)
+     Memory: 1.8M
+     CGroup: /docker/e044bf61ea7657640deb13ffaf6dfcd9a2178f48c7a226f5ccd03597663213af/system.slice/kadalu-server.service
+             └─34 /usr/sbin/kadalu-server
+
+Mar 05 08:01:45 e044bf61ea76 systemd[1]: Started Kadalu Storage Server.
+Mar 05 08:01:45 e044bf61ea76 kadalu-server[34]: [development] Kemal is ready to lead at http://0.0.0.0:3000
+```
+
+```
+docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name node1 --network kadalu --hostname node1.kadalu kadalu-storage/node
+docker run -d -v /sys/fs/cgroup/:/sys/fs/cgroup:ro --cap-add SYS_ADMIN --name node2 --network kadalu --hostname node2.kadalu kadalu-storage/node
+```
+
+Login to check if `kadalu-node` service is running
+
+```
+docker exec -it node1 /bin/bash
+root@c6c8292b9107:/# systemctl status kadalu-node
+● kadalu-node.service - Kadalu Storage node agent
+     Loaded: loaded (/lib/systemd/system/kadalu-node.service; enabled; vendor preset: enabled)
+     Active: active (running) since Fri 2021-03-05 07:49:34 UTC; 26min ago
+   Main PID: 33 (kadalu-node)
+      Tasks: 2 (limit: 2227)
+     Memory: 800.0K
+     CGroup: /docker/c6c8292b91070eec9de137ca99dc5f209d9a65dbbf3deee30d6bd8f13bd8ba6a/system.slice/kadalu-node.service
+             └─33 /usr/sbin/kadalu-node
+
+Mar 05 07:49:34 c6c8292b9107 systemd[1]: Started Kadalu Storage node agent.
+Mar 05 07:49:34 c6c8292b9107 kadalu-node[33]: [development] Kemal is ready to lead at http://0.0.0.0:3001
+```
+
+## Cluster Create
+
+Login to `kadalu-control` and create user and Cluster as required.
+
+```
+$ docker exec -it kadalu-control /bin/bash
+```
+
+```
+# Known issue, not able to set this env automatically(`http://$(hostname):3000`)
+$ export KADALU_MGMT_SERVER=http://kadalu-control.kadalu:3000
+$ kadalu register admin admin@example.com
+Enter password:
+User registered successfully.
+ID: 40e4a2c9-caf2-4a1b-92c3-3c9181e7986d
+$
+$ kadalu login admin@example.com
+Enter password:
+Successfully logged in to Kadalu Storage Server.
+App ID: fc8d1cc4-3379-4c30-a946-1523d4509b26
+
+Token saved to `~/.kadalu/app.json` Run `kadalu logout` to logout from the Server or delete the `~/.kadalu/app.json` file.
+
+$ kadalu cluster create mycluster
+Cluster created successfully.
+ID: 2861aa91-a89b-46ab-8cf8-1ee3a4a6fe53
+
+Saved as default Cluster
+$
+$ kadalu cluster list
+ ID                                    Name
+*2861aa91-a89b-46ab-8cf8-1ee3a4a6fe53  mycluster
+```
+
+Now Join the nodes
+
+```
+$ kadalu node join http://node1.kadalu:3001
+Node joined successfully.
+ID: b8567223-2881-4988-8280-84edf890ef59
+$
+$ kadalu node join http://node2.kadalu:3001
+Node joined successfully.
+ID: cbcaecc9-710a-451e-b023-c0a89493d43b
+$
+$ kadalu node list
+ID                                    Name                       Endpoint
+b8567223-2881-4988-8280-84edf890ef59  node1.kadalu               http://node1.kadalu:3001
+cbcaecc9-710a-451e-b023-c0a89493d43b  node2.kadalu               http://node2.kadalu:3001
+```
+
+Now Login to node containers and create brick directories(Note: Brick Volume need to be specified while starting the node container)
+
+```
+$ docker exec -it node1 /bin/bash
+root@node1:/# mkdir -p /bricks/gvol1
+root@node1:/# exit
+```
+
+```
+$ docker exec -it node2 /bin/bash
+root@node2:/# mkdir -p /bricks/gvol1
+root@node2:/# exit
+```
+
+Now login to control container and create and start the Volume
+
+```
+$ docker exec -it kadalu-control /bin/bash
+root@kadalu-control:/# kadalu volume create gvol1 node1.kadalu:/bricks/gvol1/b1 node2.kadalu:/bricks/gvol1/b2
+Volume creation request sent successfully.
+Task ID: 3315b28c-02a4-4490-83b1-c68c4fa62a27
+root@kadalu-control:/#
+root@kadalu-control:/# kadalu volume list
+ID                                    Name            Type            State
+c576818e-8c20-48c5-b92b-603a1aa37e11  gvol1           Distribute      Created
+root@kadalu-control:/#
+root@kadalu-control:/# kadalu volume start gvol1
+Volume start request sent successfully.
+Task ID: 41cd2c7d-95aa-433b-8e8f-f4c0a60e85fa
+root@kadalu-control:/#
+root@kadalu-control:/# kadalu volume list
+ID                                    Name            Type            State
+c576818e-8c20-48c5-b92b-603a1aa37e11  gvol1           Distribute      Started
+```
+
+## TODO:
+
+* Add Volumes for `/var/lib/kadalu` for each Node containers
+* Add Volume for `kadalu-storage/server`(For Sqlite db and other things)
+* Set the required environment variables
+* How to communicate between containers(Self-heal daemon requires to connect to other storage nodes, kadalu-node agent needs to connect to Kadalu Server/Control plane)
+* Access brick directories inside `kadalu-storage/node` container(Dynamic access when new brick added)
+* Add volume for log files or use syslog?
+* Set Proper Hostname for `kadalu-storage/node` containers.
+* Changes required in Dockerfile to build for Arm (Refer [build_arm64_static.sh](./build_arm64_static.sh))

--- a/extra/Dockerfile.node
+++ b/extra/Dockerfile.node
@@ -1,0 +1,57 @@
+FROM crystallang/crystal:0.35.1-alpine as crystal
+
+WORKDIR /app
+COPY node ./
+COPY cli ./
+
+RUN cd node && shards install --production
+RUN cd node && VERSION=${VERSION} shards build --static --release --stats --time
+
+RUN cd cli && shards install --production
+RUN cd cli && VERSION=${VERSION} shards build --static --release --stats --time
+
+FROM ubuntu:20.04 as prod
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
+COPY --from=kadalu/builder:latest /opt /opt
+
+# actual application to be copied here
+# using already installed packages from builder for faster build time
+COPY --from=kadalu/builder:latest /kadalu /kadalu
+
+RUN apt-get update -yq && \
+    apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /kadalu/templates /kadalu/volfiles
+RUN mkdir -p /var/run/gluster /var/log/glusterfs
+
+RUN mkdir -p /var/lib/kadalu /var/run/kadalu /var/lib/kadalu/volfiles /var/log/kadalu
+COPY extra/kadalu-brick@.service /lib/systemd/system/
+COPY extra/kadalu-node.service /lib/systemd/system/
+COPY extra/kadalu-brick /usr/sbin/
+RUN chmod +x /usr/sbin/kadalu-brick
+
+COPY --from=crystal /app/node/bin/kadalu-node /usr/sbin/kadalu-node
+COPY --from=crystal /app/cli/bin/kadalu /usr/sbin/kadalu
+
+ARG version="(unknown)"
+# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+ARG builddate="(unknown)"
+
+LABEL build-date="${builddate}"
+LABEL io.k8s.description="KaDalu container(glusterfsd or glustershd)"
+LABEL name="kadalu-server"
+LABEL Summary="KaDalu Server"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/kadalu/kadalu"
+LABEL vendor="kadalu"
+LABEL version="${version}"
+
+CMD ["/usr/sbin/init"]
+
+# Debugging, Comment the above line and
+# uncomment below line
+# ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/extra/entrypoint_node.sh
+++ b/extra/entrypoint_node.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+systemctl set-environment GLUSTERFSD=/opt/sbin/glusterfsd
+
+exec "$@"

--- a/extra/entrypoint_node.sh
+++ b/extra/entrypoint_node.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 systemctl set-environment GLUSTERFSD=/opt/sbin/glusterfsd
+mkdir -p /var/lib/kadalu /var/run/kadalu /var/lib/kadalu/volfiles /var/log/kadalu
 
 exec "$@"

--- a/extra/entrypoint_server.sh
+++ b/extra/entrypoint_server.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# TODO: This is not working
+if [[ -z "${KADALU_MGMT_SERVER}" ]]; then
+    export KADALU_MGMT_SERVER=http://$(hostname):3000
+fi
+
+exec "$@"

--- a/extra/kadalu-node.service
+++ b/extra/kadalu-node.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kadalu Storage node agent
+After=network.target
+
+[Service]
+PIDFile=/var/run/kadalu/node.pid
+ExecStart=/usr/sbin/kadalu-node
+
+[Install]
+WantedBy=multi-user.target

--- a/extra/kadalu-server.service
+++ b/extra/kadalu-server.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kadalu Storage Server
+After=network.target
+
+[Service]
+PIDFile=/var/run/kadalu/server.pid
+ExecStart=/usr/sbin/kadalu-server
+
+[Install]
+WantedBy=multi-user.target

--- a/node/shard.yml
+++ b/node/shard.yml
@@ -9,8 +9,6 @@ description: |
 
 license: Apache-2.0
 
-crystal: 0.35.1
-
 targets:
   kadalu-node:
     main: src/node.cr

--- a/server/shard.yml
+++ b/server/shard.yml
@@ -9,8 +9,6 @@ description: |
 
 license: Apache-2.0
 
-crystal: 0.35.1
-
 targets:
   kadalu-server:
     main: src/server.cr

--- a/server/src/db/db.cr
+++ b/server/src/db/db.cr
@@ -21,7 +21,7 @@ module MoanaDB
   end
 
   def self.init(workdir : String)
-    @@conn = DB.open("sqlite3://#{workdir}/moana.db")
+    @@conn = DB.open("sqlite3://#{workdir}/kadalu.db")
     @@conn.not_nil!.exec "PRAGMA journal_mode=WAL;"
     create_table_clusters
     create_table_nodes

--- a/server/src/db/helpers.cr
+++ b/server/src/db/helpers.cr
@@ -1,8 +1,5 @@
-require "openssl"
+require "digest/sha256"
 
 def hash_sha256(value : String)
-  hash = OpenSSL::Digest.new("SHA256")
-  hash.update(value)
-
-  hash.hexdigest
+  Digest::SHA256.digest(value).hexstring
 end

--- a/server/src/server.cr
+++ b/server/src/server.cr
@@ -67,7 +67,8 @@ class AuthHandler < Kemal::Handler
   end
 end
 
-MoanaDB.init(".")
+workdir = ENV.fetch("WORKDIR", "/var/lib/kadalu")
+MoanaDB.init(workdir)
 
 add_handler AuthHeaderHandler.new
 add_handler AuthHandler.new

--- a/volgen/shard.yml
+++ b/volgen/shard.yml
@@ -9,8 +9,6 @@ description: |
 
 license: Apache-2.0
 
-crystal: 0.35.1
-
 dependencies:
   moana_types:
     path: ../types


### PR DESCRIPTION
* Two containers are built. `kadalu-storage/server` and
  `kadalu-storage/node`
* Start one instance of `kadalu-storage/server` and multiple
  instances of `kadalu-storage/node` as required.
* Refer container-README.md for build and usage instructions

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>