### PR TITLE
Fix wrong volume type when pure distribute Volume was created

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -18,6 +18,7 @@ FROM ubuntu:20.04 as prod
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/kadalu/bin:/opt/bin:/opt/sbin:$PATH"
 COPY --from=kadalu-storage/builder:latest /opt /opt
+ENV GLUSTERFSD=/opt/sbin/glusterfsd
 
 RUN apt-get update -yq && \
     apt-get install -y --no-install-recommends python3 xfsprogs libtirpc3 init && \

--- a/extra/entrypoint_node.sh
+++ b/extra/entrypoint_node.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-systemctl set-environment GLUSTERFSD=/opt/sbin/glusterfsd
+mkdir -p /etc/systemd/system.conf.d/
 mkdir -p /var/lib/kadalu /var/run/kadalu /var/lib/kadalu/volfiles /var/log/kadalu
+
+echo "[Manager]
+DefaultEnvironment=$(while read -r Line; do echo -n "$Line " ; done < <(env))
+" > /etc/systemd/system.conf.d/myenvironment.conf
 
 exec "$@"

--- a/extra/kadalu-brick
+++ b/extra/kadalu-brick
@@ -80,8 +80,8 @@ def start_brick_process(conf):
         [
             glusterfsd,
             "-N",
-            "-p", "/var/run/kadalu/%s.pid" % conf["name"],
-            "-S", "/var/run/kadalu/%s.socket" % conf["name"],
+            "-p", "/var/run/%s.pid" % conf["name"],
+            "-S", "/var/run/%s.socket" % conf["name"],
             "--brick-name", conf["path"],
             "-l", "/var/log/kadalu/bricks/%s.log" % conf["name"],
             "--xlator-option",

--- a/server/src/default_volfiles.cr
+++ b/server/src/default_volfiles.cr
@@ -48,10 +48,6 @@ brick:
     name: "{{ volume.name }}-locks"
   - type: "features/access-control"
     name: "{{ volume.name }}-access-control"
-  - type: "features/bitrot-stub"
-    name: "{{ volume.name }}-bitrot-stub"
-    options:
-      export: "{{ brick.path }}"
   - type: "features/changelog"
     name: "{{ volume.name }}-changelog"
     options:

--- a/server/src/volume_utils.cr
+++ b/server/src/volume_utils.cr
@@ -126,7 +126,10 @@ def volume_from_request(req : MoanaTypes::VolumeCreateRequest)
   subvol_type = REPLICATE if req.replica_count > 1
   subvol_type = DISPERSE if req.disperse_count > 1
 
-  subvol_bricks_count = req.replica_count > 1 ? req.replica_count : req.disperse_count
+  subvol_bricks_count = req.bricks.size
+  if req.replica_count > 1 || req.disperse_count > 1
+    subvol_bricks_count = req.replica_count > 1 ? req.replica_count : req.disperse_count
+  end
   number_of_subvols = req.bricks.size / subvol_bricks_count
 
   volume.type = subvol_type


### PR DESCRIPTION
* Wrong Calculation was used to find the number of Sub volumes from
  volume create request.
* GLUSTERFSD env variable was not available for systemd service
* Bitrot was not built but was used in brick graph.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>