### PR TITLE
Automatically create the Pool and add nodes to the Pool

### DIFF
--- a/docs/volumes.adoc
+++ b/docs/volumes.adoc
@@ -16,6 +16,17 @@ Where
 - `server1.example.com` is the node from which the Storage unit will be exported.
 - `/exports/vol/s1` is the mounted path of Storage Unit.
 
+Automatically create the Pool and add nodes to Pool that are specified in the Volume create request by adding `--auto-create-pool` and `--auto-add-nodes`.
+
+[source,console]
+----
+[root@server1 ~]# kadalu volume create DEV/vol1 \
+    server1.example.com:/exports/vol1/s1 \
+    --auto-create-pool --auto-add-nodes
+Volume vol1 created successfully
+ID: 02b6a3a4-e704-47ee-bb05-e541a561a921
+----
+
 Create a Replicated or Mirrored Volume
 
 [source,console]

--- a/mgr/src/cmds/volumes.cr
+++ b/mgr/src/cmds/volumes.cr
@@ -2,7 +2,7 @@ require "./helpers"
 require "./volume_create_parser"
 
 struct VolumeArgs
-  property status = false, detail = false, name = "", no_start = false
+  property status = false, detail = false, name = "", no_start = false, auto_create_pool = false, auto_add_nodes = false
 end
 
 class Args
@@ -19,12 +19,20 @@ command "volume.create", "Kadalu Storage Volume Create" do |parser, args|
   parser.on("--no-start", "Don't start the Volume on Create") do
     args.volume_args.no_start = true
   end
+  parser.on("--auto-create-pool", "Auto create Pool if not exists") do
+    args.volume_args.auto_create_pool = true
+  end
+  parser.on("--auto-add-nodes", "Automatically add nodes to the Pool") do
+    args.volume_args.auto_add_nodes = true
+  end
 end
 
 handler "volume.create" do |args|
   begin
     req = VolumeRequestParser.parse(args.pos_args)
     req.no_start = args.volume_args.no_start
+    req.auto_create_pool = args.volume_args.auto_create_pool
+    req.auto_add_nodes = args.volume_args.auto_add_nodes
     args.pool_name = req.pool.name
     api_call(args, "Failed to Create Volume") do |client|
       volume = client.pool(args.pool_name).create_volume(req)

--- a/tests/all/volumes.t
+++ b/tests/all/volumes.t
@@ -30,6 +30,7 @@ nodes.each do |node|
   TEST "mkdir -p /exports/vol2"
   TEST "mkdir -p /exports/vol3"
   TEST "mkdir -p /exports/vol4"
+  TEST "mkdir -p /exports/vol5"
 end
 
 USE_NODE nodes[0]
@@ -84,6 +85,26 @@ nodes.each do |node|
 end
 
 puts TEST "kadalu pool delete DEV --mode=script"
+
+# Auto create the Pool and add nodes
+# Delete info file and restart kadalu-mgr
+# TODO: Fix this in node remove
+nodes.each do |node|
+  USE_NODE node
+  TEST "systemctl stop kadalu-mgr"
+  TEST "rm -rf /var/lib/kadalu/info"
+  TEST "systemctl start kadalu-mgr"
+end
+
+USE_NODE nodes[0]
+TEST "kadalu volume create DEV/vol5 server1:/exports/vol5/s1 server2:/exports/vol5/s2 server3:/exports/vol5/s3 --auto-create-pool --auto-add-nodes"
+TEST "kadalu volume stop DEV/vol5 --mode=script"
+TEST "kadalu volume delete DEV/vol5 --mode=script"
+nodes.each do |node|
+  USE_NODE nodes[0]
+  puts TEST "kadalu node remove DEV/#{node} --mode=script"
+end
+
 puts TEST "kadalu user logout"
 
 nodes.each do |node|

--- a/types/src/moana_types.cr
+++ b/types/src/moana_types.cr
@@ -109,6 +109,8 @@ module MoanaTypes
       pool = Pool.new,
       distribute_groups = [] of DistributeGroup,
       no_start = false,
+      auto_create_pool = false,
+      auto_add_nodes = false,
       options = Hash(String, String).new,
       metrics = Metrics.new,
       snapshot_plugin = ""


### PR DESCRIPTION
New two flags added to Volume create command to create the
Pool automatically and add the nodes to the Pool that are
specified in the Volume create statement.

- `--auto-create-pool` - Automatically create the Pool
- `--auto-add-nodes` - Automatically add the nodes to the Pool

Example:

```console
$ kadalu volume create DEV/vol1                 \
    --auto-create-pool --auto-add-nodes         \
    mirror server1.example.com:/exports/vol1/s1 \
           server2.example.com:/exports/vol1/s2 \
           server3.example.com:/exports/vol1/s3
```

Fixes: #131
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>