### PR TITLE
Fix node responses handling and node authentication

### DIFF
--- a/mgr/src/server/actions.cr
+++ b/mgr/src/server/actions.cr
@@ -10,6 +10,9 @@ struct NodeResponse
 
   def initialize(@ok, @response)
   end
+
+  def initialize(@ok, @response, @status_code)
+  end
 end
 
 struct Response


### PR DESCRIPTION
- Node authentication is done before calling the node action
- Normalized the node responses on error/exception
- Node auth error format changed to match the node response

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>