### PR TITLE
Added Mgr URL details to node on join

### DIFF
--- a/mgr/src/cmds/helpers.cr
+++ b/mgr/src/cmds/helpers.cr
@@ -70,9 +70,9 @@ def api_call(args, message, &block : MoanaClient::Client -> Nil)
     block.call(client)
   rescue ex : MoanaClient::ClientException
     STDERR.puts message
-    STDERR.puts "[HTTP Error: #{ex.status_code}] #{ex.message}"
+    STDERR.puts ex.message
     ex.node_errors.each do |node_err|
-      STDERR.puts "  [#{node_err.node_name}] #{node_err.error} (HTTP Error: #{node_err.status_code})"
+      STDERR.puts "  [#{node_err.node_name}] #{node_err.error}"
     end
     exit 1
   rescue ex : Socket::ConnectError

--- a/mgr/src/cmds/mount.cr
+++ b/mgr/src/cmds/mount.cr
@@ -40,7 +40,7 @@ handler "mount" do |args|
     api_call(args, "Failed to generate the Volfile") do |client|
       volfile = client.pool(pool_name).volume(volume_name).get_volfile("client")
 
-      volfile_dir = Path.new(GlobalConfig.workdir, "volfiles")
+      volfile_dir = "/var/lib/kadalu/volfiles"
       volfile_path = Path.new(volfile_dir, "client-#{pool_name}-#{volume_name}.vol").to_s
       Dir.mkdir_p(volfile_dir)
       File.write(volfile_path, volfile.content)

--- a/mgr/src/server/actions.cr
+++ b/mgr/src/server/actions.cr
@@ -30,14 +30,14 @@ struct Response
 end
 
 module Action
-  @@actions = Hash(String, (String -> NodeResponse)).new
+  @@actions = Hash(String, (String, HTTP::Server::Context -> NodeResponse)).new
 
-  def self.add(name, &block : String -> NodeResponse)
+  def self.add(name, &block : String, HTTP::Server::Context -> NodeResponse)
     @@actions[name] = block
   end
 
-  def self.run(name, data)
-    @@actions[name].call(data)
+  def self.run(name, data, env)
+    @@actions[name].call(data, env)
   end
 
   def self.dispatch(name : String, pool_name : String, nodes : Array(MoanaTypes::Node), data : String)

--- a/mgr/src/server/conf.cr
+++ b/mgr/src/server/conf.cr
@@ -13,7 +13,8 @@ end
 struct LocalNodeData
   include JSON::Serializable
 
-  property pool_name = "", id = "", name = "", token_hash = "", mgr_url = ""
+  property pool_name = "", id = "", name = "", token_hash = "",
+    mgr_url = "", mgr_port = 3000, mgr_https = false
 
   def initialize
   end

--- a/mgr/src/server/datastore/volumes.cr
+++ b/mgr/src/server/datastore/volumes.cr
@@ -101,7 +101,7 @@ module Datastore
             pools.name AS pool_name
      FROM volumes
      INNER JOIN distribute_groups ON volumes.id = distribute_groups.volume_id
-     INNER JOIN storage_units ON storage_units.volume_id = volumes.id
+     INNER JOIN storage_units ON storage_units.volume_id = volumes.id AND storage_units.distribute_group_id = distribute_groups.id
      INNER JOIN nodes ON nodes.id = storage_units.node_id
      INNER JOIN pools ON pools.id = volumes.pool_id
     "

--- a/mgr/src/server/plugins/helpers.cr
+++ b/mgr/src/server/plugins/helpers.cr
@@ -27,7 +27,7 @@ def handle_node_action(env)
     end
   end
 
-  resp = Action.run(action, req)
+  resp = Action.run(action, req, env)
   resp.status_code = 400 unless resp.ok
 
   resp
@@ -47,7 +47,7 @@ post "/_api/v1/:action" do |env|
   resp.to_json
 end
 
-def node_action(name, &block : String -> NodeResponse)
+def node_action(name, &block : String, HTTP::Server::Context -> NodeResponse)
   Action.add(name, &block)
 end
 

--- a/mgr/src/server/plugins/node_add.cr
+++ b/mgr/src/server/plugins/node_add.cr
@@ -4,7 +4,7 @@ require "../datastore/*"
 
 ACTION_NODE_INVITE_ACCEPT = "node_invite_accept"
 
-node_action ACTION_NODE_INVITE_ACCEPT do |data|
+node_action ACTION_NODE_INVITE_ACCEPT do |data, _env|
   req = MoanaTypes::NodeRequest.from_json(data)
 
   data_file = Path.new(GlobalConfig.workdir, "info")

--- a/mgr/src/server/plugins/ping.cr
+++ b/mgr/src/server/plugins/ping.cr
@@ -2,6 +2,6 @@ require "./helpers"
 
 ACTION_PING = "ping"
 
-node_action ACTION_PING do |_|
+node_action ACTION_PING do |_data, _env|
   NodeResponse.new(true, "")
 end

--- a/mgr/src/server/plugins/volume_create.cr
+++ b/mgr/src/server/plugins/volume_create.cr
@@ -10,16 +10,16 @@ ACTION_VALIDATE_VOLUME_CREATE = "validate_volume_create"
 ACTION_VOLUME_CREATE          = "volume_create"
 ACTION_VOLUME_CREATE_STOPPED  = "volume_create_stopped"
 
-node_action ACTION_VALIDATE_VOLUME_CREATE do |data|
+node_action ACTION_VALIDATE_VOLUME_CREATE do |data, _env|
   req = MoanaTypes::Volume.from_json(data)
   validate_volume_create(req)
 end
 
-node_action ACTION_VOLUME_CREATE do |data|
+node_action ACTION_VOLUME_CREATE do |data, _env|
   handle_volume_create(data, stopped: false)
 end
 
-node_action ACTION_VOLUME_CREATE_STOPPED do |data|
+node_action ACTION_VOLUME_CREATE_STOPPED do |data, _env|
   handle_volume_create(data, stopped: true)
 end
 

--- a/mgr/src/server/plugins/volume_list_status.cr
+++ b/mgr/src/server/plugins/volume_list_status.cr
@@ -16,7 +16,7 @@ struct VolumeStatusRequestToNode
   end
 end
 
-node_action ACTION_VOLUME_STATUS do |data|
+node_action ACTION_VOLUME_STATUS do |data, _env|
   Log.debug &.emit("Node Action", action: ACTION_VOLUME_STATUS, data: data)
 
   req = Hash(String, VolumeStatusRequestToNode).from_json(data)

--- a/mgr/src/server/plugins/volume_start_stop.cr
+++ b/mgr/src/server/plugins/volume_start_stop.cr
@@ -9,11 +9,11 @@ require "./volume_utils.cr"
 ACTION_VOLUME_START = "volume_start"
 ACTION_VOLUME_STOP  = "volume_stop"
 
-node_action ACTION_VOLUME_START do |data|
+node_action ACTION_VOLUME_START do |data, _env|
   handle_node_volume_start_stop(data, "start")
 end
 
-node_action ACTION_VOLUME_STOP do |data|
+node_action ACTION_VOLUME_STOP do |data, _env|
   handle_node_volume_start_stop(data, "stop")
 end
 

--- a/mgr/src/server/server.cr
+++ b/mgr/src/server/server.cr
@@ -138,6 +138,7 @@ module StorageMgr
 
     Log.info &.emit("Starting the Storage manager ReST API server", port: "#{Kemal.config.port}")
 
+    add_handler MgrRequestsProxyHandler.new
     add_handler AuthHandler.new
 
     # Start the API server

--- a/tests/all/node_proxy_tests.t
+++ b/tests/all/node_proxy_tests.t
@@ -1,0 +1,71 @@
+# -*- mode: ruby -*-
+
+load "#{File.dirname(__FILE__)}/../reset.t"
+
+USE_REMOTE_PLUGIN "docker"
+nodes = ["server1", "server2", "server3"]
+
+nodes.each do |node|
+  USE_NODE node
+  TEST "systemctl enable kadalu-mgr"
+  TEST "systemctl start kadalu-mgr"
+end
+
+USE_NODE nodes[0]
+puts TEST "kadalu user create admin --password=kadalu"
+puts TEST "kadalu user login admin --password=kadalu"
+puts TEST "kadalu pool create DEV"
+RUN "umount /mnt/vol2"
+RUN "rm -rf /mnt/vol2"
+
+nodes.each do |node|
+  USE_NODE nodes[0]
+  TEST "kadalu node add DEV/#{node}"
+end
+
+nodes.each do |node|
+  USE_NODE node
+  RUN "rm -rf /exports/*"
+  TEST "mkdir -p /exports/vol1"
+end
+
+# After nodes are added, try execute commands in other agent nodes
+USE_NODE nodes[1]
+puts TEST "kadalu user login admin --password=kadalu"
+
+# Distribute
+TEST "kadalu volume create DEV/vol1 server1:/exports/vol1/s1 server2:/exports/vol1/s2 server3:/exports/vol1/s3"
+
+nodes.each do |node|
+  USE_NODE node
+
+  # TODO: Validate Number of Storage unit or brick processes running
+  puts TEST "ps ax | grep storage_unit | grep vol1"
+end
+
+USE_NODE nodes[1]
+TEST "mkdir /mnt/vol1"
+TEST "chattr +i /mnt/vol1"
+TEST "mount -t kadalu #{nodes[1]}:DEV/vol1 /mnt/vol1"
+
+TEST "echo \"Hello World\" > /mnt/vol1/f1"
+# TODO: Validate this value below
+content = TEST "cat /mnt/vol1/f1"
+EQUAL content.strip, "Hello World", "/mnt/vol1/f1 content is \"Hello World\""
+
+TEST "kadalu volume stop DEV/vol1 --mode=script"
+TEST "kadalu volume delete DEV/vol1 --mode=script"
+
+nodes.each do |node|
+  USE_NODE nodes[0]
+  puts TEST "kadalu node remove DEV/#{node} --mode=script"
+end
+
+puts TEST "kadalu pool delete DEV --mode=script"
+
+puts TEST "kadalu user logout"
+
+nodes.each do |node|
+  USE_NODE node
+  puts TEST "cat /var/log/kadalu/mgr.log"
+end

--- a/types/src/moana_types.cr
+++ b/types/src/moana_types.cr
@@ -25,7 +25,8 @@ module MoanaTypes
   struct NodeRequest
     include JSON::Serializable
 
-    property name = "", endpoint = "", pool_name = "", mgr_node_id = ""
+    property name = "", endpoint = "", pool_name = "", mgr_node_id = "",
+      mgr_url = "", mgr_port = 3000, mgr_https = false
 
     def initialize
     end


### PR DESCRIPTION
- Storage Manager URL will be captured from `request.remote_address`
  while accepting the node join request.
- Storage manager port and https details are sent in the invite
- Once joined, If any manager API request is received in agent,
  re-route all the requests to manager URL.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>