### PR TITLE
Use Manager hostname as set in the Mgr service

### DIFF
--- a/mgr/src/cmds/mgr.cr
+++ b/mgr/src/cmds/mgr.cr
@@ -4,7 +4,8 @@ require "../server/*"
 struct MgrArgs
   property metrics_interval_seconds = 15,
     workdir = "/var/lib/kadalu",
-    logdir = ""
+    logdir = "",
+    hostname = ""
 end
 
 class Args
@@ -18,6 +19,9 @@ command "mgr", "Start Kadalu Storage Manager" do |parser, args|
   end
   parser.on("--logdir=LOGDIR", "Kadalu Log directory") do |logdir|
     args.mgr_args.logdir = logdir
+  end
+  parser.on("--hostname=HOSTNAME", "Hostname") do |hostname|
+    args.mgr_args.hostname = hostname
   end
 end
 

--- a/mgr/src/server/conf.cr
+++ b/mgr/src/server/conf.cr
@@ -14,7 +14,7 @@ struct LocalNodeData
   include JSON::Serializable
 
   property pool_name = "", id = "", name = "", token_hash = "",
-    mgr_url = "", mgr_port = 3000, mgr_https = false, mgr_token = ""
+    mgr_hostname = "", mgr_port = 3000, mgr_https = false, mgr_token = ""
 
   def initialize
   end

--- a/mgr/src/server/routes.cr
+++ b/mgr/src/server/routes.cr
@@ -25,8 +25,8 @@ class MgrRequestsProxyHandler < Kemal::Handler
     # No proxy required if
     # - the current process is a Manager or
     # - it is a internal request or
-    # - mgr_url is not set in Local node
-    if GlobalConfig.local_node.mgr_url == "" ||
+    # - mgr_hostname is not set in Local node
+    if GlobalConfig.local_node.mgr_hostname == "" ||
        env.request.path.starts_with?("/_api") ||
        Datastore.manager?
       return call_next(env)
@@ -34,7 +34,7 @@ class MgrRequestsProxyHandler < Kemal::Handler
 
     mgr_url = URI.new(
       scheme: GlobalConfig.local_node.mgr_https ? "https" : "http",
-      host: GlobalConfig.local_node.mgr_url,
+      host: GlobalConfig.local_node.mgr_hostname,
       port: GlobalConfig.local_node.mgr_port,
       path: env.request.path,
       query: env.request.query_params

--- a/mgr/src/server/server.cr
+++ b/mgr/src/server/server.cr
@@ -51,7 +51,7 @@ module StorageMgr
 
     if GlobalConfig.agent
       loop do
-        if GlobalConfig.local_node.mgr_url == ""
+        if GlobalConfig.local_node.mgr_hostname == ""
           break
         end
 
@@ -63,7 +63,7 @@ module StorageMgr
 
           mgr_url = URI.new(
             scheme: GlobalConfig.local_node.mgr_https ? "https" : "http",
-            host: GlobalConfig.local_node.mgr_url,
+            host: GlobalConfig.local_node.mgr_hostname,
             port: GlobalConfig.local_node.mgr_port,
             path: "/api/v1/pools/#{GlobalConfig.local_node.pool_name}/nodes/#{GlobalConfig.local_node.name}/services"
           )
@@ -133,7 +133,9 @@ module StorageMgr
       File.write(info_file, data.to_json)
     end
 
-    if File.exists?(hostname_file)
+    if args.mgr_args.hostname != ""
+      GlobalConfig.local_hostname = args.mgr_args.hostname
+    elsif File.exists?(hostname_file)
       GlobalConfig.local_hostname = File.read(hostname_file).strip
     end
 

--- a/types/src/moana_types.cr
+++ b/types/src/moana_types.cr
@@ -26,7 +26,8 @@ module MoanaTypes
     include JSON::Serializable
 
     property name = "", endpoint = "", pool_name = "", mgr_node_id = "",
-      mgr_url = "", mgr_port = 3000, mgr_https = false, mgr_token = ""
+      mgr_url = "", mgr_port = 3000, mgr_https = false, mgr_token = "",
+      mgr_hostname = ""
 
     def initialize
     end


### PR DESCRIPTION
While accepting the node join request, mgr hostname
was taken from `env.remote_address`. This may become a
problem if the Manager IP changes frequently or Mgr node
is rebuilt.

With this PR mgr hostname will be used as set in the Mgr instance.
Default is `hostname` of the Mgr node. Control this by adding
required hostname in `/var/lib/kadalu/hostname` file or by adding
additional argument to mgr start command

```
kadalu mgr --hostname=server1.example.com
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>