### PR TITLE
Reduce the length of Brick Socket file to avoid the listen-path error

### DIFF
--- a/.github/workflows/on-pr-submit.yml
+++ b/.github/workflows/on-pr-submit.yml
@@ -26,7 +26,7 @@ jobs:
         run: make lint
       - name: Install Binnacle
         run: |
-          curl -L https://github.com/kadalu/binnacle/releases/latest/download/binnacle -o binnacle
+          curl -L https://github.com/kadalu/binnacle/releases/download/0.4.1/binnacle -o binnacle
           chmod +x ./binnacle
           sudo mv ./binnacle /usr/local/bin/binnacle
           binnacle --version

--- a/mgr/src/cmds/mount_script.cr
+++ b/mgr/src/cmds/mount_script.cr
@@ -220,6 +220,7 @@ module MountKadalu
     parse_options(raw_options)
     set_volfile_server_options(hostname, volume_name, volfile_path)
     set_process_name
+    add_option("--fs-display-name", "#{hostname}:#{pool_name}/#{volume_name}")
 
     # Subdir mount: Add slash if not added
     add_option("--subdir-mount", "/#{@@options["--subdir-mount"].lstrip("/")}") if @@options["--subdir-mount"]?

--- a/mgr/src/server/services/storage_unit.cr
+++ b/mgr/src/server/services/storage_unit.cr
@@ -19,7 +19,7 @@ class StorageUnitService < Service
     @pid_file = "/var/run/kadalu/#{@id}.pid"
     @args = [
       "--volfile-id", @id,
-      "-S", "/var/run/kadalu/#{@id}.socket",
+      "-S", "/var/run/kadalu/#{storage_unit.node.id}.#{escaped_path(storage_unit.path)}.socket",
       "-p", @pid_file,
       "--brick-name", storage_unit.path,
       "-l", "/var/log/kadalu/storage_units/#{@id}.log",


### PR DESCRIPTION
```
option transport.unix.listen-path has value length 110 > 108
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>