### PR TITLE
Fix CLI help Usage messages

### DIFF
--- a/mgr/src/cmds/users.cr
+++ b/mgr/src/cmds/users.cr
@@ -17,7 +17,7 @@ def validated_username(args)
 end
 
 command "user.create", "Create a Kadalu Storage user" do |parser, args|
-  parser.banner = "Usage: kadalu user create USERNAME [arguments]\n\nArguments:"
+  parser.banner = "Usage: kadalu user create USERNAME [arguments]"
   parser.on("--pool=POOL_NAME", "Storage pool name") do |name|
     args.user_args.pool_name = name
   end

--- a/mgr/src/cmds/volumes.cr
+++ b/mgr/src/cmds/volumes.cr
@@ -18,7 +18,7 @@ def pool_and_volume_name(value)
 end
 
 command "volume.create", "Kadalu Storage Volume Create" do |parser, args|
-  parser.banner = "Usage: kadalu volume create POOL/VOLNAME TYPE STORAGE_UNITS [arguments]\n\nArguments:"
+  parser.banner = "Usage: kadalu volume create POOL/VOLNAME TYPE STORAGE_UNITS [arguments]"
   parser.on("--no-start", "Don't start the volume upon creation") do
     args.volume_args.no_start = true
   end


### PR DESCRIPTION
* Enhanced to show separate list of subcommands and arguments
* Added default help message to commands and subcommands if not specified

Example CLI output:

```console
$ kadalu volume -h
Usage: kadalu volume [subcommand] [arguments]

Subcommands:
    create                           Kadalu Storage Volume Create
    start                            Start the Kadalu Storage volume
    stop                             Stop the Kadalu Storage volume
    list                             Volumes list of a Kadalu Storage pool
    delete                           Delete the Kadalu Storage volume
    set                              Set options to the Kadalu Storage volume
    reset                            Reset the options of the Kadalu Storage volume

Arguments:
    -h, --help                       Show this help
    --mode=MODE                      Script mode
    --json                           Pretty print in JSON
    --version                        Show version information
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>