### PR TITLE
The option -n is for user's full name

### DIFF
--- a/mgr/src/cmds/users.cr
+++ b/mgr/src/cmds/users.cr
@@ -32,7 +32,7 @@ command "user.create", "Create a Kadalu Storage user" do |parser, args|
   parser.on("-p PASSWORD", "--password=PASSWORD", "Password") do |password|
     args.user_args.password = password
   end
-  parser.on("-n NAME", "--name=NAME", "Username") do |name|
+  parser.on("-n NAME", "--name=NAME", "Name of the user") do |name|
     args.user_args.name = name
   end
 end


### PR DESCRIPTION
I had fixed the help text earlier from 'User Name' to "Username" but I was under the impression that it was username, I now realize that it is the full name of the user.