### PR TITLE
mgr: Add support to rename pool

### DIFF
--- a/mgr/src/cmds/pools.cr
+++ b/mgr/src/cmds/pools.cr
@@ -60,3 +60,20 @@ handler "pool.delete" do |args|
     puts "Pool #{args.pool_name} deleted"
   end
 end
+
+command "pool.rename", "Rename the Kadalu Storage Pool" do |parser, _|
+  parser.banner = "Usage: kadalu pool rename Exiting_POOL New_POOL [arguments]"
+end
+
+handler "pool.rename" do |args|
+  command_error "Existing & New Pool name is required" if args.pos_args.size < 2
+  args.pool_name = args.pos_args[0]
+  new_pool_name = args.pos_args[1]
+  next unless (args.script_mode || yes("Are you sure you want to rename the pool? [y/N]"))
+
+  api_call(args, "Failed to rename the pool") do |client|
+    pool = client.pool(args.pool_name).rename(new_pool_name)
+    handle_json_output(pool, args)
+    puts "Pool #{args.pool_name} renamed to #{new_pool_name}"
+  end
+end

--- a/mgr/src/server/datastore/pools.cr
+++ b/mgr/src/server/datastore/pools.cr
@@ -125,4 +125,9 @@ module Datastore
     query = "DELETE FROM pools WHERE id = ?"
     connection.exec(query, pool_id)
   end
+
+  def rename_pool_name(pool_id, new_pool_name)
+    query = "UPDATE pools SET name = ? WHERE id = ?"
+    connection.exec(query, new_pool_name, pool_id)
+  end
 end

--- a/sdk/crystal/src/pools.cr
+++ b/sdk/crystal/src/pools.cr
@@ -90,5 +90,21 @@ module StorageManager
         StorageManager.error_response(response)
       end
     end
+
+    def rename(new_pool_name : String)
+      url = "#{@client.url}/api/v1/pools/#{@name}/rename"
+
+      response = StorageManager.http_post(
+        url,
+        {"new_pool_name": new_pool_name}.to_json,
+        headers: @client.auth_header
+      )
+
+      if response.status_code == 200
+        MoanaTypes::Pool.from_json(response.body)
+      else
+        StorageManager.error_response(response)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR introduces new subcommand under pool to be able to rename it.
Example:
```
root@kadalu-dev:/src/mgr# ./bin/kadalu pool rename dev16 dev17 --json
Are you sure you want to rename the pool? [y/N]: y
{
  "id": "8984af72-19e9-4005-a828-d10804043b86",
  "name": "dev17",
  "nodes": [
    {
      "id": "",
      "name": "",
      "state": "",
      "endpoint": "",
      "addresses": [],
      "token": "",
      "pool": {
        "id": "",
        "name": "",
        "nodes": []
      }
    }
  ]
}
```

Fixes: #209 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>