### PR TITLE
mgr: Add subcommand to rename volume

### DIFF
--- a/mgr/src/cmds/volumes.cr
+++ b/mgr/src/cmds/volumes.cr
@@ -266,3 +266,24 @@ handler "volume.reset" do |args|
     puts "Volume #{volume_name} options reset"
   end
 end
+
+command "volume.rename", "Rename the Kadalu Storage volume" do |parser, _|
+  parser.banner = "Usage: kadalu volume rename POOL/VOLNAME POOL/NEW_VOLNAME [arguments]"
+end
+
+handler "volume.rename" do |args|
+  if args.pos_args.size < 2
+    puts "POOL/VOLNAME POOL/NEW_VOLNAME is required"
+    exit(0)
+  end
+
+  args.pool_name, volume_name = pool_and_volume_name(args.pos_args.size > 0 ? args.pos_args[0] : "")
+  new_pool_name, new_volname = pool_and_volume_name(args.pos_args.size > 1 ? args.pos_args[1] : "")
+
+  api_call(args, "Failed to rename the volume") do |client|
+    volume = client.pool(args.pool_name).volume(volume_name).rename(new_pool_name, new_volname)
+
+    handle_json_output(volume, args)
+    puts "Volume #{args.pool_name}/#{volume_name} renamed to #{new_pool_name}/#{new_volname} successfully!"
+  end
+end

--- a/mgr/src/server/datastore/volumes.cr
+++ b/mgr/src/server/datastore/volumes.cr
@@ -276,4 +276,9 @@ module Datastore
     query = "SELECT COUNT(id) FROM volumes WHERE pool_id = ? AND id = ?"
     connection.scalar(query, pool_id, volume_id).as(Int64) > 0
   end
+
+  def rename_volume(pool_id, volume_id, new_volname)
+    query = "UPDATE volumes SET name = ? WHERE pool_id = ? AND id = ?"
+    connection.exec(query, new_volname, pool_id, volume_id)
+  end
 end

--- a/mgr/src/server/plugins/volume_rename.cr
+++ b/mgr/src/server/plugins/volume_rename.cr
@@ -1,0 +1,41 @@
+require "../datastore/*"
+
+post "/api/v1/pools/:pool_name/volumes/:volume_name/rename" do |env|
+  pool_name = env.params.url["pool_name"]
+  volume_name = env.params.url["volume_name"]
+
+  new_pool_name = env.params.json["new_pool_name"].as(String)
+  new_volname = env.params.json["new_volname"].as(String)
+
+  next forbidden(env) unless Datastore.maintainer?(env.user_id, pool_name, volume_name)
+
+  pool = Datastore.get_pool(pool_name)
+  if pool.nil?
+    halt(env, status_code: 400, response: ({"error": "Pool does not exist."}.to_json))
+  end
+
+  volume = Datastore.get_volume(pool_name, volume_name)
+  if volume.nil?
+    halt(env, status_code: 400, response: ({"error": "Volume does not exist."}.to_json))
+  end
+
+  if new_pool_name != pool_name
+    halt(env, status_code: 400, response: ({"error": "Volume rename outside the pool #{pool_name} is not supported."}.to_json))
+  end
+
+  if volume_name == new_volname
+    halt(env, status_code: 400, response: ({"error": "Existing & New volname are the same."}.to_json))
+  end
+
+  if volume.state == "Started"
+    halt(env, status_code: 400, response: ({"error": "Volume should be stopped before renaming."}.to_json))
+  end
+
+  Datastore.rename_volume(pool.id, volume.id, new_volname)
+
+  volume.name = new_volname
+
+  env.response.status_code = 200
+
+  volume.to_json
+end

--- a/sdk/crystal/src/volumes.cr
+++ b/sdk/crystal/src/volumes.cr
@@ -171,5 +171,21 @@ module StorageManager
         StorageManager.error_response(response)
       end
     end
+
+    def rename(new_pool_name : String, new_volname : String)
+      url = "#{@client.url}/api/v1/pools/#{@pool_name}/volumes/#{@name}/rename"
+
+      response = StorageManager.http_post(
+        url,
+        {"new_pool_name": new_pool_name, "new_volname": new_volname}.to_json,
+        headers: @client.auth_header
+      )
+
+      if response.status_code == 200
+        MoanaTypes::Volume.from_json(response.body)
+      else
+        StorageManager.error_response(response)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR introduces new subcommand `rename` to rename a `volume`.
Example:
```
root@kadalu-dev:/src/mgr# ./bin/kadalu volume rename dev4/vol1 vol3
Failed to rename the volume
Volume should be stopped before renaming.
root@kadalu-dev:/src/mgr# ./bin/kadalu volume stop dev4/vol1     
Are you sure you want to stop the volume? [y/N]: y
Volume vol1 stopped
root@kadalu-dev:/src/mgr# ./bin/kadalu volume rename dev4/vol1 vol3
Volume vol1 renamed to vol3 successfully!
root@kadalu-dev:/src/mgr# ./bin/kadalu volume list
Name       ID                                    State    Type          Size  Inodes
dev4/vol3  e8b901e4-26ab-4431-8de7-3921cb3882cb  Stopped  Distribute  869GiB   61.0M
```
Fixes: #117 
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>