### PR TITLE
Serve Volfiles from Storage Unit processes

### DIFF
--- a/mgr/src/server/default_volfiles.cr
+++ b/mgr/src/server/default_volfiles.cr
@@ -65,6 +65,7 @@ storage_unit:
       auth-path: "{{ storage_unit.path }}"
       "auth.login.{{ storage_unit.path }}.ssl-allow": "*"
       "auth.addr.{{ storage_unit.path }}.allow": "*"
+      volspec-directory: "/var/lib/kadalu/volfiles"
   - type: "debug/io-stats"
     name: "{{ storage_unit.path }}"
   - type: "features/index"

--- a/mgr/src/server/plugins/volume_option_set_reset.cr
+++ b/mgr/src/server/plugins/volume_option_set_reset.cr
@@ -6,6 +6,30 @@ require "../datastore/*"
 require "./ping"
 require "./volume_utils.cr"
 
+ACTION_VOLUME_OPTION_CHANGE = "volume_option_change"
+
+node_action ACTION_VOLUME_OPTION_CHANGE do |data, _env|
+  services, volfiles, _ = VolumeRequestToNode.from_json(data)
+
+  # Save all newly generated Volfiles
+  if !volfiles[GlobalConfig.local_node.id]?.nil?
+    Dir.mkdir_p(Path.new(GlobalConfig.workdir, "volfiles"))
+    volfiles[GlobalConfig.local_node.id].each do |volfile|
+      File.write(Path.new(GlobalConfig.workdir, "volfiles", "#{volfile.name}.vol"), volfile.content)
+    end
+  end
+
+  # Send SIGHUP to all the processes (Storage Unit and SHD processes)
+  unless services[GlobalConfig.local_node.id]?.nil?
+    services[GlobalConfig.local_node.id].each do |service|
+      svc = Service.from_json(service.to_json)
+      svc.signal(Signal::HUP)
+    end
+  end
+
+  NodeResponse.new(true, "")
+end
+
 # POST /api/v1/pools/:pool_id/volumes/:volume_id/options/set
 post "/api/v1/pools/:pool_name/volumes/:volume_name/options/set" do |env|
   pool_name = env.params.url["pool_name"]
@@ -30,6 +54,24 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/set" do |env|
   Datastore.update_volume_options(volume.id, volume.options)
 
   volume = Datastore.get_volume(pool_name, volume_name)
+
+  nodes = participating_nodes(pool_name, volume)
+
+  # Regenerate the Volfiles
+  services, volfiles = services_and_volfiles(volume.not_nil!)
+
+  # Notify all the Storage Units
+  resp = dispatch_action(
+    ACTION_VOLUME_OPTION_CHANGE,
+    pool_name,
+    nodes,
+    {services, volfiles, volume}.to_json
+  )
+
+  if !resp.ok
+    halt(env, status_code: 400, response: (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
+  end
+
   env.response.status_code = 201
   volume.to_json
 end
@@ -58,6 +100,24 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/reset" do |env|
   Datastore.update_volume_options(volume.id, volume.options)
 
   volume = Datastore.get_volume(pool_name, volume_name)
+
+  nodes = participating_nodes(pool_name, volume)
+
+  # Regenerate the Volfiles
+  services, volfiles = services_and_volfiles(volume.not_nil!)
+
+  # Notify all the Storage Units
+  resp = dispatch_action(
+    ACTION_VOLUME_OPTION_CHANGE,
+    pool_name,
+    nodes,
+    {services, volfiles, volume}.to_json
+  )
+
+  if !resp.ok
+    halt(env, status_code: 400, response: (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
+  end
+
   env.response.status_code = 201
   volume.to_json
 end

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -22,8 +22,8 @@ RUN sed -i 's/#PermitRootLogin yes/PermitRootLogin yes/' /etc/ssh/sshd_config \
     /etc/lvm/lvm.conf &&                                                      \
   systemctl mask getty.target
 
-RUN git clone https://github.com/gluster/glusterfs && \
-    cd glusterfs && \
+RUN git clone https://github.com/kadalu/glusterfs && \
+    cd glusterfs && git checkout -b kadalu_1 origin/kadalu_1 && \
     ./autogen.sh && ./configure --disable-linux-io_uring && make && make install && ldconfig
 
 RUN curl -fsSL https://crystal-lang.org/install.sh | sudo bash


### PR DESCRIPTION
Mount script changes are pending but it is possible to mount the Volume directly using `glusterfs` command (See tests/all/volumes.t).

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>