### PR TITLE
Use supervisord to manage the Kadalu mgr service instead of systemd

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yq &&                                                     \
-    apt-get install -y --no-install-recommends lvm2 curl attr sqlite3 ca-certificates gnupg2
+    apt-get install -y --no-install-recommends lvm2 curl attr sqlite3 ca-certificates gnupg2 supervisor
 
 RUN sed -i.save -e "s#udev_sync = 1#udev_sync = 0#"                           \
     -e "s#udev_rules = 1#udev_rules = 0#"                                     \
@@ -15,5 +15,7 @@ RUN echo 'deb https://kadalu.tech/pkgs/1.0.x/ubuntu/22.04 /' | tee /etc/apt/sour
 RUN curl -fsSL https://kadalu.tech/pkgs/1.0.x/ubuntu/22.04/KEY.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/kadalu.gpg > /dev/null
 RUN apt-get update -yq && apt-get install -y kadalu-storage
 
-ENTRYPOINT ["/usr/sbin/kadalu", "mgr", "--workdir=/var/lib/kadalu", "--logdir=/var/log/kadalu"]
+COPY container/supervisord.conf /etc/supervisor/conf.d/
+
+ENTRYPOINT ["/usr/bin/supervisord"]
 EXPOSE 3000

--- a/container/supervisord.conf
+++ b/container/supervisord.conf
@@ -1,0 +1,5 @@
+[supervisord]
+nodaemon=true
+
+[program:kadalu-mgr]
+command=/usr/sbin/kadalu mgr --workdir=/var/lib/kadalu --logdir=/var/log/kadalu


### PR DESCRIPTION
Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>