### PR TITLE
mgr/actions: Handle Socket Address Info Error

### DIFF
--- a/mgr/src/server/actions.cr
+++ b/mgr/src/server/actions.cr
@@ -64,6 +64,11 @@ module Action
           node.id == "" ? node.name : node.id,
           NodeResponse.new(false, {"error": "Node is not reachable"}.to_json)
         )
+      rescue Socket::Addrinfo::Error
+        resp.set_node_response(
+          node.id == "" ? node.name : node.id,
+          NodeResponse.new(false, {"error": "Hostname lookup failed for node #{node.name}"}.to_json)
+        )
       end
     end
 


### PR DESCRIPTION
This PR rescues exception "Socket::Addrinfo::Error" which was being raised, when node add request was made to a non-existent node. Handle the exception gracefully by sending a failed noderesponse to sdk/cli.

Fixes: #283
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>