### PR TITLE
mgr: Add fix-layout process after volume_expansion

### DIFF
--- a/mgr/src/server/plugins/volume_utils.cr
+++ b/mgr/src/server/plugins/volume_utils.cr
@@ -518,3 +518,32 @@ def validate_and_add_nodes(pool, req)
 
   nodes
 end
+
+def add_fix_layout_service(services, pool_name, volume_name, node, storage_unit)
+  # ports = Datastore.reserved_ports(pool_id, node.id)
+
+  # volfile_servers = [] of String
+  # ports.each do |port|
+  #   volfile_servers.push("#{node_name}:#{port}")
+  # end
+
+  service = FixLayoutService.new(pool_name, volume_name, storage_unit)
+  services[node.id] << service.unit
+
+  services
+end
+
+def start_fix_layout_service(data)
+  services, _, _ = VolumeRequestToNode.from_json(data)
+
+  unless services[GlobalConfig.local_node.id]?.nil?
+    services[GlobalConfig.local_node.id].each do |service|
+      svc = Service.from_json(service.to_json)
+      if svc.name == "fixlayoutservice"
+        svc.start
+      end
+    end
+  end
+
+  NodeResponse.new(true, "")
+end

--- a/mgr/src/server/services/fix_layout.cr
+++ b/mgr/src/server/services/fix_layout.cr
@@ -1,0 +1,22 @@
+require "./services"
+
+class FixLayoutService < Service
+  getter path : String,
+    args : Array(String),
+    pid_file : String,
+    id : String
+
+  def initialize(pool_name, volume_name, storage_unit)
+    @create_pid_file = true
+
+    @path = Path[PROGRAM_NAME].expand.to_s
+    @id = "#{volume_name}-fix-layout"
+    @pid_file = "/run/kadalu/#{@id}.pid"
+    @args = [
+      "_rebalance", "--fix-layout",
+      "#{pool_name}/#{volume_name}",
+      storage_unit.path, "--volfile-servers",
+      "#{storage_unit.node.name}:#{storage_unit.port}",
+    ]
+  end
+end


### PR DESCRIPTION
This PR,
- starts fix-layout as process, which calls fix-layout crawler/sets virtual xattrs defined in rebalance-tool.
- combines restart-shd-process and fix-layout node_actions to limit multiple requests to nodes.

Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>