### PR TITLE
Refactor handling of API errors

### DIFF
--- a/mgr/src/server/plugins/config_snapshots.cr
+++ b/mgr/src/server/plugins/config_snapshots.cr
@@ -9,16 +9,12 @@ require "./volume_utils.cr"
 post "/api/v1/config-snapshots" do |env|
   data = MoanaTypes::ConfigSnapshot.from_json(env.request.body.not_nil!)
   snap_name = data.name
-  if snap_name.strip == ""
-    halt(env, status_code: 400, response: ({"error": "Invalid Snapshot name"}.to_json))
-  end
+  api_exception(snap_name.strip == "", ({"error": "Invalid Snapshot name"}.to_json))
 
   snap_dir = "#{GlobalConfig.workdir}/config-snapshots" + "/#{snap_name}"
 
   if Dir.exists?(snap_dir)
-    unless data.overwrite
-      halt(env, status_code: 400, response: ({"error": "Snapshot already exists"}.to_json))
-    end
+    api_exception(!data.overwrite, ({"error": "Snapshot already exists"}.to_json))
 
     # Delete the current Snapshot directory if overwrite=true
     FileUtils.rm_rf(snap_dir)
@@ -45,9 +41,7 @@ delete "/api/v1/config-snapshots/:snap_name" do |env|
 
   snap_dir = "#{GlobalConfig.workdir}/config-snapshots" + "/#{snap_name}"
 
-  unless Dir.exists?(snap_dir)
-    halt(env, status_code: 400, response: ({"error": "Snapshot doesn't exists"}.to_json))
-  end
+  api_exception(!Dir.exists?(snap_dir), ({"error": "Snapshot doesn't exists"}.to_json))
 
   FileUtils.rm_rf(snap_dir)
 
@@ -67,9 +61,7 @@ get "/api/v1/config-snapshots/:snap_name" do |env|
 
   snap = Datastore.get_config_snapshot(snap_name)
 
-  if snap.nil?
-    halt(env, status_code: 400, response: ({"error": "Snapshot #{snap_name} does not exist"}.to_json))
-  end
+  api_exception(snap.nil?, ({"error": "Snapshot #{snap_name} does not exist"}.to_json))
 
   env.response.status_code = 200
 

--- a/mgr/src/server/plugins/helpers.cr
+++ b/mgr/src/server/plugins/helpers.cr
@@ -4,6 +4,23 @@ require "kemal"
 
 require "../actions"
 
+# Custom API exception
+class ApiException < Exception
+  getter status_code = 200, response = ""
+
+  def initialize(@status_code, @response)
+    super "#{@status_code} - #{@response}"
+  end
+end
+
+def api_exception(condition, response, status_code = 400)
+  raise ApiException.new(status_code, response) if condition
+end
+
+def forbidden_api_exception(condition)
+  api_exception(condition, ({"error": "Forbidden. Insufficient permissions"}).to_json, 403)
+end
+
 def handle_node_action(env)
   action = env.params.url["action"]
   req = env.params.json["data"].as(String)

--- a/mgr/src/server/plugins/volfiles.cr
+++ b/mgr/src/server/plugins/volfiles.cr
@@ -22,9 +22,8 @@ get "/api/v1/pools/:pool_name/volumes/:volume_name/volfiles/:volfile_name" do |e
   storage_unit = env.params.query["storage_unit"]?
 
   volume = Datastore.get_volume(pool_name, volume_name)
-  unless volume
-    halt(env, status_code: 400, response: ({"error": "Invalid Volume name"}.to_json))
-  end
+  api_exception(volume.nil?, ({"error": "Invalid Volume name"}.to_json))
+  volume = volume.not_nil!
 
   tmpl = volfile_get(volfile_name)
   content = if storage_unit

--- a/mgr/src/server/plugins/volume_option_set_reset.cr
+++ b/mgr/src/server/plugins/volume_option_set_reset.cr
@@ -22,17 +22,15 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/set" do |env|
   pool_name = env.params.url["pool_name"]
   volume_name = env.params.url["volume_name"]
 
-  next forbidden(env) unless Datastore.maintainer?(env.user_id, pool_name)
+  forbidden_api_exception(!Datastore.maintainer?(env.user_id, pool_name))
 
   pool = Datastore.get_pool(pool_name)
-  if pool.nil?
-    halt(env, status_code: 400, response: ({"error": "The Pool(#{pool_name}) doesn't exists"}.to_json))
-  end
+  api_exception(pool.nil?, ({"error": "The Pool(#{pool_name}) doesn't exists"}.to_json))
 
   volume = Datastore.get_volume(pool_name, volume_name)
-  if volume.nil?
-    halt(env, status_code: 400, response: ({"error": "The Volume(#{volume_name}) doesn't exists"}.to_json))
-  end
+  api_exception(volume.nil?, ({"error": "The Volume(#{volume_name}) doesn't exists"}.to_json))
+
+  volume = volume.not_nil!
 
   volume_options = Hash(String, String).from_json(env.request.body.not_nil!)
   volume.options = volume.options.merge(volume_options)
@@ -55,9 +53,7 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/set" do |env|
     {services, volfiles, volume}.to_json
   )
 
-  if !resp.ok
-    halt(env, status_code: 400, response: (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
-  end
+  api_exception(!resp.ok, (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
 
   env.response.status_code = 201
   volume.to_json
@@ -68,17 +64,15 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/reset" do |env|
   pool_name = env.params.url["pool_name"]
   volume_name = env.params.url["volume_name"]
 
-  next forbidden(env) unless Datastore.maintainer?(env.user_id, pool_name)
+  forbidden_api_exception(!Datastore.maintainer?(env.user_id, pool_name))
 
   pool = Datastore.get_pool(pool_name)
-  if pool.nil?
-    halt(env, status_code: 400, response: ({"error": "The Pool(#{pool_name}) doesn't exists"}.to_json))
-  end
+  api_exception(pool.nil?, ({"error": "The Pool(#{pool_name}) doesn't exists"}.to_json))
 
   volume = Datastore.get_volume(pool_name, volume_name)
-  if volume.nil?
-    halt(env, status_code: 400, response: ({"error": "The Volume(#{volume_name}) doesn't exists"}.to_json))
-  end
+  api_exception(volume.nil?, ({"error": "The Volume(#{volume_name}) doesn't exists"}.to_json))
+
+  volume = volume.not_nil!
 
   volume_option_keys = Array(String).from_json(env.request.body.not_nil!)
   volume.options = volume.options.reject(volume_option_keys)
@@ -101,9 +95,7 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/options/reset" do |env|
     {services, volfiles, volume}.to_json
   )
 
-  if !resp.ok
-    halt(env, status_code: 400, response: (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
-  end
+  api_exception(!resp.ok, (node_errors("Failed to notify Storage units on Option change", resp.node_responses).to_json))
 
   env.response.status_code = 201
   volume.to_json

--- a/mgr/src/server/plugins/volume_rename.cr
+++ b/mgr/src/server/plugins/volume_rename.cr
@@ -7,37 +7,35 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/rename" do |env|
   new_pool_name = env.params.json["new_pool_name"].as(String)
   new_volname = env.params.json["new_volname"].as(String)
 
-  next forbidden(env) unless Datastore.maintainer?(env.user_id, pool_name, volume_name)
+  forbidden_api_exception(!Datastore.maintainer?(env.user_id, pool_name, volume_name))
 
   pool = Datastore.get_pool(pool_name)
-  if pool.nil?
-    halt(env, status_code: 400, response: ({"error": "Pool does not exist."}.to_json))
-  end
+  api_exception(pool.nil?, ({"error": "Pool does not exist."}.to_json))
+  pool = pool.not_nil!
 
   volume = Datastore.get_volume(pool_name, volume_name)
-  if volume.nil?
-    halt(env, status_code: 400, response: ({"error": "Volume does not exist."}.to_json))
-  end
+  api_exception(volume.nil?, ({"error": "Volume does not exist."}.to_json))
+
+  volume = volume.not_nil!
 
   new_pool = Datastore.get_pool(new_pool_name)
 
-  if new_pool.nil?
-    halt(env, status_code: 400, response: ({"error": "Target Pool #{new_pool_name} does not exist."}.to_json))
-  end
+  api_exception(new_pool.nil?, ({"error": "Target Pool #{new_pool_name} does not exist."}.to_json))
+  new_pool = new_pool.not_nil!
 
-  if Datastore.volume_name_exists_by_pool_id?(new_volname, new_pool.id)
-    halt(env, status_code: 400, response: ({"error": "Volume #{new_volname} already exists in target Pool #{new_pool_name}"}.to_json))
-  end
+  api_exception(
+    Datastore.volume_name_exists_by_pool_id?(new_volname, new_pool.id),
+    ({"error": "Volume #{new_volname} already exists in target Pool #{new_pool_name}"}.to_json)
+  )
 
-  if volume.state == "Started"
-    halt(env, status_code: 400, response: ({"error": "Volume should be stopped before renaming."}.to_json))
-  end
+  api_exception(volume.state == "Started", ({"error": "Volume should be stopped before renaming."}.to_json))
 
   transfer_volume = pool_name != new_pool_name
   if transfer_volume
-    if Datastore.node_part_of_other_volume?(pool.id, volume.id)
-      halt(env, status_code: 400, response: ({"error": "Node(s) are part of other volume(s) in the current pool."}.to_json))
-    end
+    api_exception(
+      Datastore.node_part_of_other_volume?(pool.id, volume.id),
+      ({"error": "Node(s) are part of other volume(s) in the current pool."}.to_json)
+    )
 
     # Update pool_name in .info file at every local_data_nodes
     nodes = participating_nodes(pool_name, volume)
@@ -48,9 +46,7 @@ post "/api/v1/pools/:pool_name/volumes/:volume_name/rename" do |env|
       {"new_pool_name": new_pool_name, "old_pool_name": pool_name}.to_json,
     )
 
-    if !resp.ok
-      halt(env, status_code: 400, response: ({"error": "Failed to rename volume"}.to_json))
-    end
+    api_exception(!resp.ok, ({"error": "Failed to rename volume"}.to_json))
 
     # TODO: Find cmd to pass node_id & update in DB as arr to avoid for loop
     Datastore.update_volume_to_new_pool(new_volname, new_pool.id, volume.id)

--- a/mgr/src/server/routes.cr
+++ b/mgr/src/server/routes.cr
@@ -41,6 +41,17 @@ def internal_api_or_ping?(path)
   path.starts_with?("/_api") || path == "/ping"
 end
 
+class ApiExceptionHandler < Kemal::Handler
+  def call(env)
+    call_next env
+  rescue ex : ApiException
+    env.response.content_type = "application/json"
+    env.response.status_code = ex.status_code
+    env.response.print ex.response
+    env.response.close
+  end
+end
+
 class MgrRequestsProxyHandler < Kemal::Handler
   def call(env)
     # No proxy required if

--- a/mgr/src/server/server.cr
+++ b/mgr/src/server/server.cr
@@ -166,6 +166,7 @@ module StorageMgr
 
     Log.info &.emit("Starting the Storage manager ReST API server", port: "#{Kemal.config.port}")
 
+    add_handler ApiExceptionHandler.new
     add_handler MgrRequestsProxyHandler.new
     add_handler AuthHandler.new
 


### PR DESCRIPTION
`halt` can only be used within the blocks and it will not work in other places. Reusing code was very difficult since all the logic should be placed in the ReST route blocks.

Now, API exception is introduced. This allows to move the common functionalities to one place and handle this exception in ReST routes.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.tech>