### PR TITLE
cmds: Unmount the temp dir after rebalance(fix-layout, migrate-data)

### DIFF
--- a/mgr/src/cmds/rebalance_process.cr
+++ b/mgr/src/cmds/rebalance_process.cr
@@ -1,4 +1,5 @@
 require "xattr"
+require "file_utils"
 require "moana_types"
 
 require "./helpers"
@@ -247,6 +248,16 @@ class Rebalancer
     # TODO: Handle Mount failure and other errors
     execute("glusterfs", args)
   end
+
+  def umount
+    # TODO: Handle umount errors except mount not exists
+    execute("umount", [@mount_dir])
+
+    # TODO: Handle errors
+    execute("chattr", ["-i", @mount_dir])
+
+    FileUtils.rm_rf(@mount_dir)
+  end
 end
 
 struct RebalanceArgs
@@ -295,6 +306,7 @@ handler "_rebalance" do |args|
     if do_rebalance
       reb.mount(args.rebalance_args.volfile_servers)
       reb.fix_layout
+      reb.umount
     else
       STDERR.puts "Status file of previous fix-layout exists. Please remove it to start fix-layout again"
     end
@@ -311,6 +323,7 @@ handler "_rebalance" do |args|
     if do_rebalance
       reb.mount(args.rebalance_args.volfile_servers)
       reb.migrate_data
+      reb.umount
     else
       STDERR.puts "Status file of previous migrate-data exists. Please remove it to start migrate-data again"
     end

--- a/mgr/src/cmds/rebalance_process.cr
+++ b/mgr/src/cmds/rebalance_process.cr
@@ -256,7 +256,7 @@ class Rebalancer
     # TODO: Handle errors
     execute("chattr", ["-i", @mount_dir])
 
-    FileUtils.rm_rf(@mount_dir)
+    FileUtils.rmdir(@mount_dir)
   end
 end
 


### PR DESCRIPTION
Unmount the temp dir used to construct the rebalanced volume after its completion.
- Remove non-mutable attr
- Umount the dir
- Remove the dir

Todo: Handle exceptions caused by above commands.

Fixes: #288
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>