### PR TITLE
rebalance_process: List entries before setting migrate-data xattr

### DIFF
--- a/lint/.ameba.yml
+++ b/lint/.ameba.yml
@@ -1,3 +1,0 @@
-Lint/UselessAssign:
-  Excluded:
-    - mgr/src/cmds/rebalance_process.cr

--- a/lint/.ameba.yml
+++ b/lint/.ameba.yml
@@ -1,0 +1,3 @@
+Lint/UselessAssign:
+  Excluded:
+    - mgr/src/cmds/rebalance_process.cr

--- a/mgr/src/cmds/rebalance_process.cr
+++ b/mgr/src/cmds/rebalance_process.cr
@@ -139,6 +139,7 @@ class Rebalancer
 
         backend_full_path = Path.new(@backend_dir, rel_path)
         if File.directory?(backend_full_path)
+          entries = Dir.new(Path.new(@mount_dir, rel_path).to_s).entries
           @migrate_data_status.scanned_bytes += BLOCK_SIZE
           all_dirs << rel_path
           next

--- a/mgr/src/cmds/rebalance_process.cr
+++ b/mgr/src/cmds/rebalance_process.cr
@@ -139,7 +139,9 @@ class Rebalancer
 
         backend_full_path = Path.new(@backend_dir, rel_path)
         if File.directory?(backend_full_path)
-          entries = Dir.new(Path.new(@mount_dir, rel_path).to_s).entries
+          # TODO: Fix ENOENT issue in mount and remove list entries for,
+          # Correct use of rebalance multiprocesses & improved time complexity.
+          _entries = Dir.new(Path.new(@mount_dir, rel_path).to_s).entries
           @migrate_data_status.scanned_bytes += BLOCK_SIZE
           all_dirs << rel_path
           next


### PR DESCRIPTION
List entries at @mount_dir to avoid bug "No such file or directory", during migrate-data xattr set.

Fixes: #293
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>