### PR TITLE
rebalance: Add subcommand 'kadalu rebalance status <>'

### DIFF
--- a/mgr/src/cmds/rebalance.cr
+++ b/mgr/src/cmds/rebalance.cr
@@ -1,5 +1,13 @@
 require "./helpers"
 
+struct RebalanceArgs
+  property detail = false
+end
+
+class Args
+  property rebalance_args = RebalanceArgs.new
+end
+
 command "rebalance.start", "Start Rebalancing Kadalu Storage volume" do |parser, _|
   parser.banner = "Usage: kadalu rebalance start POOL/VOLNAME [arguments]"
 end
@@ -46,8 +54,129 @@ handler "rebalance.stop" do |args|
   end
 end
 
-command "rebalance.status", "Show Kadalu Storage volume rebalance status" do |parser, _|
+command "rebalance.status", "Show Kadalu Storage volume rebalance status" do |parser, args|
   parser.banner = "Usage: kadalu rebalance status POOL/VOLNAME [arguments]"
+  parser.on("--detail", "Show detailed rebalance status info of individual storage units") do
+    args.rebalance_args.detail = true
+  end
+end
+
+def rebalance_status_summary(volume, args)
+  total_migrate_data_processes = 0
+  total_non_started_migrate_data_processes = 0
+  total_completed_migrate_data_processes = 0
+  total_failed_migrate_data_processes = 0
+  rebalance_status = ""
+  highest_estimate_seconds = -2147483648
+  sum_of_scanned_bytes = 0
+  sum_of_total_bytes = 0
+  sum_of_progress = 0
+
+  puts "Name                       : #{volume.pool.name}/#{volume.name}"
+  puts "Type                       : #{volume.type}"
+  puts "ID                         : #{volume.id}"
+
+  volume.distribute_groups.each do |dist_grp|
+    storage_unit = dist_grp.storage_units[0]
+    migrate_data_status = storage_unit.migrate_data_status
+    total_migrate_data_processes += 1
+
+    case migrate_data_status.state
+    when "not started"
+      total_non_started_migrate_data_processes += 1
+    when "complete"
+      total_completed_migrate_data_processes += 1
+    when "failed"
+      total_failed_migrate_data_processes += 1
+    end
+
+    if migrate_data_status.estimate_seconds.to_i64 > highest_estimate_seconds
+      highest_estimate_seconds = migrate_data_status.estimate_seconds.to_i64
+    end
+
+    sum_of_scanned_bytes += migrate_data_status.scanned_bytes.to_i64
+    sum_of_total_bytes += migrate_data_status.total_bytes.to_i64
+    sum_of_progress += migrate_data_status.progress.to_i64
+  end
+
+  printf("Progress                   : %.2f %%\n", (sum_of_progress/total_migrate_data_processes))
+  printf("Estimate Seconds           : %i\n", highest_estimate_seconds)
+  printf("Scanned                    : %s / %s\n",
+    (sum_of_scanned_bytes/total_migrate_data_processes).to_i64.humanize_bytes, (sum_of_total_bytes/total_migrate_data_processes).to_i64.humanize_bytes)
+  puts
+
+  if total_completed_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "complete"
+  elsif total_failed_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "fail"
+  elsif total_non_started_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "not started"
+  else
+    rebalance_status = "partial"
+  end
+
+  puts "Volume #{volume.name} Rebalance Status            : #{rebalance_status}"
+  puts "Total Number of Rebalance Process       : #{total_migrate_data_processes}"
+  puts "Number of Completed Rebalance Process   : #{total_completed_migrate_data_processes}"
+  puts "Number of Failed Rebalance Process      : #{total_failed_migrate_data_processes}"
+end
+
+def detailed_rebalance_status(volume, args)
+  total_migrate_data_processes = 0
+  total_completed_migrate_data_processes = 0
+  total_non_started_migrate_data_processes = 0
+  total_failed_migrate_data_processes = 0
+  rebalance_status = ""
+
+  puts "Name                                    : #{volume.pool.name}/#{volume.name}"
+  puts "Type                                    : #{volume.type}"
+  puts "ID                                      : #{volume.id}"
+
+  volume.distribute_groups.each_with_index do |dist_grp, dist_grp_index|
+    storage_unit = dist_grp.storage_units[0]
+    migrate_data_status = storage_unit.migrate_data_status
+
+    total_migrate_data_processes += 1
+
+    case migrate_data_status.state
+    when "not started"
+      total_non_started_migrate_data_processes += 1
+    when "complete"
+      total_completed_migrate_data_processes += 1
+    when "failed"
+      total_failed_migrate_data_processes += 1
+    end
+
+    printf("Distribute group %-2s\n", dist_grp_index + 1)
+    printf(
+      "    Storage unit %-3s                    : %s:%s\n",
+      1,
+      storage_unit.node.name,
+      storage_unit.path,
+    )
+
+    printf("     Status                             : %s\n", migrate_data_status.state)
+    printf("     Progress                           : %s %%\n", migrate_data_status.progress)
+    printf("     Scanned                            : %s / %s\n", migrate_data_status.scanned_bytes.humanize_bytes, migrate_data_status.total_bytes.humanize_bytes)
+    printf("     Duration Seconds                   : %s\n", migrate_data_status.duration_seconds)
+    printf("     Estimate Seconds                   : %s\n", migrate_data_status.estimate_seconds)
+    puts
+  end
+
+  if total_completed_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "complete"
+  elsif total_failed_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "fail"
+  elsif total_non_started_migrate_data_processes == total_migrate_data_processes
+    rebalance_status = "not started"
+  else
+    rebalance_status = "partial"
+  end
+
+  puts "Volume #{volume.name} Rebalance Status            : #{rebalance_status}"
+  puts "Total Number of Rebalance Process       : #{total_migrate_data_processes}"
+  puts "Number of Completed Rebalance Process   : #{total_completed_migrate_data_processes}"
+  puts "Number of Failed Rebalance Process      : #{total_failed_migrate_data_processes}"
 end
 
 handler "rebalance.status" do |args|
@@ -55,11 +184,15 @@ handler "rebalance.status" do |args|
     command_error "Pool/Volname is required" if args.pos_args.size == 0
     args.pool_name, volume_name = pool_and_volume_name(args.pos_args.size > 0 ? args.pos_args[0] : "")
     api_call(args, "Failed to show rebalance status of volume") do |client|
-      status = client.pool(args.pool_name).volume(volume_name).rebalance_status
+      volume = client.pool(args.pool_name).volume(volume_name).rebalance_status
 
-      handle_json_output(status, args)
+      handle_json_output(volume, args)
 
-      puts "Rebalance status of volume #{volume_name}"
+      if args.rebalance_args.detail
+        detailed_rebalance_status(volume, args)
+      else
+        rebalance_status_summary(volume, args)
+      end
     end
   rescue ex : InvalidVolumeRequest
     STDERR.puts "Failed to show rebalance status of Kadalu Storage Volume"

--- a/mgr/src/cmds/rebalance.cr
+++ b/mgr/src/cmds/rebalance.cr
@@ -45,3 +45,25 @@ handler "rebalance.stop" do |args|
     exit 1
   end
 end
+
+command "rebalance.status", "Show Kadalu Storage volume rebalance status" do |parser, _|
+  parser.banner = "Usage: kadalu rebalance status POOL/VOLNAME [arguments]"
+end
+
+handler "rebalance.status" do |args|
+  begin
+    command_error "Pool/Volname is required" if args.pos_args.size == 0
+    args.pool_name, volume_name = pool_and_volume_name(args.pos_args.size > 0 ? args.pos_args[0] : "")
+    api_call(args, "Failed to show rebalance status of volume") do |client|
+      status = client.pool(args.pool_name).volume(volume_name).rebalance_status
+
+      handle_json_output(status, args)
+
+      puts "Rebalance status of volume #{volume_name}"
+    end
+  rescue ex : InvalidVolumeRequest
+    STDERR.puts "Failed to show rebalance status of Kadalu Storage Volume"
+    STDERR.puts ex
+    exit 1
+  end
+end

--- a/mgr/src/cmds/rebalance.cr
+++ b/mgr/src/cmds/rebalance.cr
@@ -71,10 +71,17 @@ def rebalance_status_summary(volume, args)
   sum_of_scanned_bytes = 0
   sum_of_total_bytes = 0
   sum_of_progress = 0
+  fix_layout_status = volume.distribute_groups[0].storage_units[0].fix_layout_status
 
   puts "Name                       : #{volume.pool.name}/#{volume.name}"
   puts "Type                       : #{volume.type}"
   puts "ID                         : #{volume.id}"
+
+  puts "Fix-Layout Status          : #{fix_layout_status.state}"
+  if fix_layout_status.state != "not started"
+    puts "Total Dirs Scanned         : #{fix_layout_status.total_dirs}"
+    puts "Duration                   : #{fix_layout_status.duration_seconds}"
+  end
 
   volume.distribute_groups.each do |dist_grp|
     storage_unit = dist_grp.storage_units[0]
@@ -126,11 +133,19 @@ def detailed_rebalance_status(volume, args)
   total_completed_migrate_data_processes = 0
   total_non_started_migrate_data_processes = 0
   total_failed_migrate_data_processes = 0
+  fix_layout_status = volume.distribute_groups[0].storage_units[0].fix_layout_status
   rebalance_status = ""
 
   puts "Name                                    : #{volume.pool.name}/#{volume.name}"
   puts "Type                                    : #{volume.type}"
   puts "ID                                      : #{volume.id}"
+
+  puts "Fix-Layout Status                       : #{fix_layout_status.state}"
+  if fix_layout_status.state != "not started"
+    puts "Total Dirs Scanned                      : #{fix_layout_status.total_dirs}"
+    puts "Duration                                : #{fix_layout_status.duration_seconds}"
+  end
+  puts
 
   volume.distribute_groups.each_with_index do |dist_grp, dist_grp_index|
     storage_unit = dist_grp.storage_units[0]
@@ -156,10 +171,12 @@ def detailed_rebalance_status(volume, args)
     )
 
     printf("     Status                             : %s\n", migrate_data_status.state)
-    printf("     Progress                           : %s %%\n", migrate_data_status.progress)
-    printf("     Scanned                            : %s / %s\n", migrate_data_status.scanned_bytes.humanize_bytes, migrate_data_status.total_bytes.humanize_bytes)
-    printf("     Duration Seconds                   : %s\n", migrate_data_status.duration_seconds)
-    printf("     Estimate Seconds                   : %s\n", migrate_data_status.estimate_seconds)
+    if migrate_data_status.state != "not started"
+      printf("     Progress                           : %s %%\n", migrate_data_status.progress)
+      printf("     Scanned                            : %s / %s\n", migrate_data_status.scanned_bytes.humanize_bytes, migrate_data_status.total_bytes.humanize_bytes)
+      printf("     Duration Seconds                   : %s\n", migrate_data_status.duration_seconds)
+      printf("     Estimate Seconds                   : %s\n", migrate_data_status.estimate_seconds)
+    end
     puts
   end
 

--- a/mgr/src/cmds/volumes.cr
+++ b/mgr/src/cmds/volumes.cr
@@ -338,8 +338,8 @@ handler "volume.expand" do |args|
       puts "ID: #{volume.id}"
 
       puts "Proceed to the rebalancing of volume #{req.name} by following the below steps."
-      puts "To start the rebalancing of volume: `kadalu volume rebalnce-start #{args.pool_name}/#{req.name}`"
-      puts "To force stop the rebalancing of volume: `kadalu volume rebalnce-stop #{args.pool_name}/#{req.name}`"
+      puts "To start the rebalancing of volume: `kadalu rebalance start #{args.pool_name}/#{req.name}`"
+      puts "To force stop the rebalancing of volume: `kadalu rebalnce stop #{args.pool_name}/#{req.name}`"
     end
   rescue ex : InvalidVolumeRequest
     STDERR.puts "Volume expand failed"

--- a/mgr/src/server/plugins/volume_expand.cr
+++ b/mgr/src/server/plugins/volume_expand.cr
@@ -136,10 +136,6 @@ put "/api/v1/pools/:pool_name/volumes" do |env|
 
   set_volume_metrics(req)
 
-  # Add only the first node for fix-layout service
-  services = add_fix_layout_service(services, pool.not_nil!.name, req.name, nodes[0],
-    volume.not_nil!.distribute_groups[0].storage_units[0])
-
   existing_nodes = participating_nodes(pool_name, volume)
 
   # Add only the first existing node for fix-layout service

--- a/mgr/src/server/plugins/volume_rebalance_status.cr
+++ b/mgr/src/server/plugins/volume_rebalance_status.cr
@@ -1,0 +1,94 @@
+require "moana_types"
+
+require "../conf"
+require "./helpers"
+require "../datastore/*"
+require "./ping"
+require "./volume_utils.cr"
+
+REBALNCE_DIR = "/var/lib/kadalu/rebalance"
+
+ACTION_REBALANCE_STATUS = "action_rebalance_status"
+
+# Calculate the status file with highest estimate_seconds and return that file data from node.
+node_action ACTION_REBALANCE_STATUS do |data, _env|
+  services, volume = ServiceRequestToNodeWithVolume.from_json(data)
+  int_min = "-2147483648"
+  rebalance_status_file_with_highest_estimate_in_secs = ""
+  status_file_path = ""
+  rebalance_dir = Path.new(WORKDIR, "rebalance", "#{volume.name}").to_s
+  node_resp = Hash(String, MoanaTypes::MigrateDataRebalanceStatus).new
+
+  unless services[GlobalConfig.local_node.id]?.nil?
+    services[GlobalConfig.local_node.id].each do |service|
+      svc = Service.from_json(service.to_json)
+      puts "svc: #{svc}"
+      # TODO: Add check for svc.running?
+      if svc.name == "migratedataservice"
+        status_file_path = "#{rebalance_dir}/#{svc.id}.json"
+        if File.exists?(status_file_path)
+          data = MoanaTypes::MigrateDataRebalanceStatus.from_json(File.read(status_file_path))
+          puts "data"
+          if data.estimate_seconds.to_i64 > int_min.to_i64
+            int_min = data.estimate_seconds
+            rebalance_status_file_with_highest_estimate_in_secs = status_file_path
+          end
+        end
+      end
+    end
+  end
+
+  if rebalance_status_file_with_highest_estimate_in_secs != ""
+    node_resp[GlobalConfig.local_node.id] = MoanaTypes::MigrateDataRebalanceStatus.from_json(File.read(rebalance_status_file_with_highest_estimate_in_secs))
+    NodeResponse.new(true, node_resp.to_json)
+  else
+    NodeResponse.new(true, (node_resp[GlobalConfig.local_node.id] = MoanaTypes::MigrateDataRebalanceStatus.new).to_json)
+  end
+end
+
+get "/api/v1/pools/:pool_name/volumes/:volume_name/rebalance_status" do |env|
+  pool_name = env.params.url["pool_name"]
+  volume_name = env.params.url["volume_name"]
+
+  forbidden_api_exception(!Datastore.maintainer?(env.user_id, pool_name, volume_name))
+
+  volume = Datastore.get_volume(pool_name, volume_name)
+  api_exception(volume.nil?, {"error": "Volume doesn't exists"}.to_json)
+  volume = volume.not_nil!
+  pool = volume.not_nil!.pool
+
+  nodes = participating_nodes(pool_name, volume)
+
+  # TODO: Add to missed_ops if a node is not reachable [Check if this is required, since node ping check is done]
+
+  # Validate if all the nodes are reachable.
+  resp = dispatch_action(ACTION_PING, pool_name, nodes, "")
+  api_exception(!resp.ok, node_errors("Not all participant nodes are reachable", resp.node_responses).to_json)
+
+  services = construct_migrate_data_service_request(volume)
+
+  resp = dispatch_action(
+    ACTION_REBALANCE_STATUS,
+    pool_name,
+    nodes,
+    {services, volume}.to_json
+  )
+
+  api_exception(!resp.ok, node_errors("Failed to get rebalance status of volume #{volume.name}", resp.node_responses).to_json)
+
+  # Goto every participating node of volume's workdir/rebalance/volume_name
+  # Fetch the highest estimate seconds value in that node
+  # construct status data which is highest estimate seconds of all nodes.
+  # Return by adding Rebalances status to Class Volume or Class StorageUnit in JSON
+
+  # Constraints
+  # How to show migrate-data has crashed [when svc.running? is false and complete: false]
+
+  # nodes.each do |node|
+  # 	puts "resp: #{resp}"
+  # end
+  puts "resp1: #{resp}"
+
+  env.response.status_code = 200
+  volume.to_json
+end

--- a/mgr/src/server/plugins/volume_rebalance_status.cr
+++ b/mgr/src/server/plugins/volume_rebalance_status.cr
@@ -8,7 +8,8 @@ require "./volume_utils.cr"
 
 REBALNCE_DIR = "/var/lib/kadalu/rebalance"
 
-ACTION_REBALANCE_STATUS = "action_rebalance_status"
+ACTION_FIX_LAYOUT_STATUS   = "action_fix_layout_status"
+ACTION_MIGRATE_DATA_STATUS = "action_migrate_data_status"
 
 struct RebalanceStatusRequestToNode
   include JSON::Serializable
@@ -21,23 +22,49 @@ end
 
 alias RebalanceRequestToNode = Tuple(String, Hash(String, Array(MoanaTypes::ServiceUnit)), Hash(String, RebalanceStatusRequestToNode))
 
-# TODO: Assign migrate-data state at volume level
-def assign_migrate_data_state(migrate_data_status, svc)
-  return migrate_data_status if migrate_data_status.state == "not started"
+# TODO: Assign state at volume level
+def assign_state(status, svc)
+  return status if status.state == "not started"
 
-  if svc.running? == false && migrate_data_status.complete == false
-    migrate_data_status.state = "failed"
+  if svc.running? == false && status.complete == false
+    status.state = "failed"
   elsif svc.running? == true
-    migrate_data_status.state = "running"
-  elsif migrate_data_status.complete == true
-    migrate_data_status.state = "complete"
+    status.state = "running"
+  elsif status.complete == true
+    status.state = "complete"
   end
 
-  migrate_data_status
+  status
 end
 
-# Calculate the status file with highest estimate_seconds and return that file data from node.
-node_action ACTION_REBALANCE_STATUS do |data, _env|
+node_action ACTION_FIX_LAYOUT_STATUS do |data, _env|
+  volume_name, services, request = RebalanceRequestToNode.from_json(data)
+  status_file_path = ""
+  rebalance_dir = Path.new(WORKDIR, "rebalance", "#{volume_name}").to_s
+  request = Hash(String, RebalanceStatusRequestToNode).from_json(request.to_json)
+  local_node_id = GlobalConfig.local_node.id
+  node_resp = RebalanceStatusRequestToNode.new
+
+  if services.has_key?(local_node_id) && request.has_key?(local_node_id)
+    svc = Service.from_json(services[local_node_id][0].to_json)
+    storage_unit = request[local_node_id].storage_units[0]
+    if svc.id == "rebalance-fix-layout-#{storage_unit.path.gsub("/", "%2F")}"
+      status_file_path = "#{rebalance_dir}/#{svc.id}.json"
+      if File.exists?(status_file_path)
+        storage_unit.fix_layout_status = MoanaTypes::FixLayoutRebalanceStatus.from_json(File.read(status_file_path))
+      else
+        storage_unit.fix_layout_status.state = "not started"
+      end
+      storage_unit.fix_layout_status = assign_state(storage_unit.fix_layout_status, svc)
+
+      node_resp.storage_units << storage_unit
+    end
+  end
+
+  NodeResponse.new(true, node_resp.to_json)
+end
+
+node_action ACTION_MIGRATE_DATA_STATUS do |data, _env|
   volume_name, services, request = RebalanceRequestToNode.from_json(data)
   status_file_path = ""
   rebalance_dir = Path.new(WORKDIR, "rebalance", "#{volume_name}").to_s
@@ -57,7 +84,7 @@ node_action ACTION_REBALANCE_STATUS do |data, _env|
           else
             storage_unit.migrate_data_status.state = "not started"
           end
-          storage_unit.migrate_data_status = assign_migrate_data_state(storage_unit.migrate_data_status, svc)
+          storage_unit.migrate_data_status = assign_state(storage_unit.migrate_data_status, svc)
 
           node_resp.storage_units << storage_unit
         end
@@ -66,6 +93,20 @@ node_action ACTION_REBALANCE_STATUS do |data, _env|
   end
 
   NodeResponse.new(true, node_resp.to_json)
+end
+
+def construct_fix_layout_service_request(pool_name, nodes, volume)
+  req = Hash(String, RebalanceStatusRequestToNode).new
+  services = Hash(String, Array(MoanaTypes::ServiceUnit)).new
+
+  # Add only the first existing node & first storage_unit for fix-layout service
+  storage_unit = volume.distribute_groups[0].storage_units[0]
+  req[storage_unit.node.id] = RebalanceStatusRequestToNode.new if req[storage_unit.node.id]?.nil?
+  req[storage_unit.node.id].storage_units << storage_unit
+  services = add_fix_layout_service(services, pool_name, volume.name, nodes[0],
+    volume.distribute_groups[0].storage_units[0])
+
+  {req, services}
 end
 
 def construct_migrate_data_service_request(pool_name, volume)
@@ -102,24 +143,44 @@ get "/api/v1/pools/:pool_name/volumes/:volume_name/rebalance_status" do |env|
   resp = dispatch_action(ACTION_PING, pool_name, nodes, "")
   api_exception(!resp.ok, node_errors("Not all participant nodes are reachable", resp.node_responses).to_json)
 
-  request, services = construct_migrate_data_service_request(pool_name, volume)
-
+  request, services = construct_fix_layout_service_request(pool_name, nodes, volume)
+  first_node = [] of MoanaTypes::Node
+  first_node << nodes[0]
   resp = dispatch_action(
-    ACTION_REBALANCE_STATUS,
+    ACTION_FIX_LAYOUT_STATUS,
+    pool_name,
+    first_node,
+    {volume_name, services, request}.to_json
+  )
+
+  api_exception(!resp.ok, node_errors("Failed to get fix-layout status of volume #{volume.name}", resp.node_responses).to_json)
+
+  storage_unit = volume.distribute_groups[0].storage_units[0]
+  if resp.node_responses[storage_unit.node.id].ok
+    node_resp = RebalanceStatusRequestToNode.from_json(resp.node_responses[storage_unit.node.id].response)
+    su = node_resp.storage_units[0]
+    if su.node.id == storage_unit.node.id && su.path == storage_unit.path
+      storage_unit.fix_layout_status = su.fix_layout_status
+    end
+  end
+
+  request, services = construct_migrate_data_service_request(pool_name, volume)
+  resp = dispatch_action(
+    ACTION_MIGRATE_DATA_STATUS,
     pool_name,
     nodes,
     {volume_name, services, request}.to_json
   )
 
-  api_exception(!resp.ok, node_errors("Failed to get rebalance status of volume #{volume.name}", resp.node_responses).to_json)
+  api_exception(!resp.ok, node_errors("Failed to get migrate-data status of volume #{volume.name}", resp.node_responses).to_json)
 
   volume.distribute_groups.each do |dist_grp|
     storage_unit = dist_grp.storage_units[0]
     if resp.node_responses[storage_unit.node.id].ok
       node_resp = RebalanceStatusRequestToNode.from_json(resp.node_responses[storage_unit.node.id].response)
-      node_resp.storage_units.each do |su|
-        if su.node.id == storage_unit.node.id && su.path == storage_unit.path
-          storage_unit.migrate_data_status = su.migrate_data_status
+      node_resp.storage_units.each do |s_unit|
+        if s_unit.node.id == storage_unit.node.id && s_unit.path == storage_unit.path
+          storage_unit.migrate_data_status = s_unit.migrate_data_status
         end
       end
     end

--- a/mgr/src/server/plugins/volume_utils.cr
+++ b/mgr/src/server/plugins/volume_utils.cr
@@ -15,7 +15,6 @@ VOLUME_ID_XATTR_NAME = "trusted.glusterfs.volume-id"
 
 alias VolumeRequestToNode = Tuple(Hash(String, Array(MoanaTypes::ServiceUnit)), Hash(String, Array(MoanaTypes::Volfile)), MoanaTypes::Volume)
 alias VolumeRequestToNodeWithAction = Tuple(Hash(String, Array(MoanaTypes::ServiceUnit)), Hash(String, Array(MoanaTypes::Volfile)), MoanaTypes::Volume, String)
-alias ServiceRequestToNodeWithVolume = Tuple(Hash(String, Array(MoanaTypes::ServiceUnit)), MoanaTypes::Volume)
 
 ACTION_VALIDATE_VOLUME_CREATE = "validate_volume_create"
 ACTION_VOLUME_CREATE          = "volume_create"

--- a/mgr/src/server/plugins/volume_utils.cr
+++ b/mgr/src/server/plugins/volume_utils.cr
@@ -537,6 +537,7 @@ end
 
 def add_fix_layout_service(services, pool_name, volume_name, node, storage_unit)
   service = FixLayoutService.new(pool_name, volume_name, storage_unit)
+  services[node.id] = [] of MoanaTypes::ServiceUnit unless services[node.id]?
   services[node.id] << service.unit
 
   services

--- a/mgr/src/server/plugins/volume_utils.cr
+++ b/mgr/src/server/plugins/volume_utils.cr
@@ -549,14 +549,3 @@ def add_migrate_data_service(services, pool_name, volume_name, node, storage_uni
 
   services
 end
-
-def construct_migrate_data_service_request(volume)
-  services = Hash(String, Array(MoanaTypes::ServiceUnit)).new
-
-  volume.distribute_groups.each do |dist_grp|
-    services = add_migrate_data_service(services, volume.pool.name, volume.name,
-      dist_grp.storage_units[0].node, dist_grp.storage_units[0])
-  end
-
-  services
-end

--- a/sdk/crystal/src/volumes.cr
+++ b/sdk/crystal/src/volumes.cr
@@ -221,5 +221,19 @@ module StorageManager
     def rebalance_stop
       volume_rebalance_start_stop("stop")
     end
+
+    def rebalance_status
+      url = "#{@client.url}/api/v1/pools/#{@pool_name}/volumes/#{@name}/rebalance_status"
+
+      response = StorageManager.http_get(
+        url,
+        headers: @client.auth_header
+      )
+      if response.status_code == 200
+        MoanaTypes::Volume.from_json(response.body)
+      else
+        StorageManager.error_response(response)
+      end
+    end
   end
 end

--- a/tests/all/volumes.t
+++ b/tests/all/volumes.t
@@ -272,6 +272,10 @@ EQUAL "3", (TEST "ls /exports/vol15/s3/d1/f8 /exports/vol15/s3/d2/f4 /exports/vo
 EQUAL "4", (TEST "ls /exports/vol15/s3_e/d1/f1 /exports/vol15/s3_e/d1/f5 /exports/vol15/s3_e/d2/f8 /exports/vol15/s3_e/d3/f8 | wc -l").strip, "Check for migrate-data in server3 s3_e unit"
 
 USE_NODE nodes[0]
+
+TEST "kadalu rebalance status DEV/vol15"
+TEST "kadalu rebalance status DEV/vol15 --detail"
+
 TEST "umount /mnt/vol15"
 TEST "rmdir /mnt/vol15"
 TEST "kadalu volume stop DEV/vol15 --mode=script"

--- a/types/src/moana_types.cr
+++ b/types/src/moana_types.cr
@@ -91,9 +91,10 @@ module MoanaTypes
       node = Node.new,
       type = "",
       fs = "",
+      service = ServiceUnit.new,
       metrics = Metrics.new,
       heal_metrics = HealMetrics.new,
-      service = ServiceUnit.new
+      migrate_data_status = MigrateDataRebalanceStatus.new
 
     def initialize(node_name, @port, @path)
       @node.name = node_name
@@ -245,7 +246,7 @@ module MoanaTypes
     include JSON::Serializable
 
     property complete = false, progress = 0, scanned_bytes = 0_i64,
-      total_bytes = 0_i64, duration_seconds = 0, estimate_seconds = 0
+      total_bytes = 0_i64, duration_seconds = 0, estimate_seconds = 0, state = "failed"
 
     def initialize
     end

--- a/types/src/moana_types.cr
+++ b/types/src/moana_types.cr
@@ -94,6 +94,7 @@ module MoanaTypes
       service = ServiceUnit.new,
       metrics = Metrics.new,
       heal_metrics = HealMetrics.new,
+      fix_layout_status = FixLayoutRebalanceStatus.new,
       migrate_data_status = MigrateDataRebalanceStatus.new
 
     def initialize(node_name, @port, @path)
@@ -255,7 +256,7 @@ module MoanaTypes
   struct FixLayoutRebalanceStatus
     include JSON::Serializable
 
-    property complete = false, total_dirs = 0, duration_seconds = 0
+    property complete = false, total_dirs = 0, duration_seconds = 0, state = "failed"
 
     def initialize
     end


### PR DESCRIPTION
This PR adds support to display status of rebalance processes(migrate-data) at volume level by default and, 
status of rebalance processes of all storage units with `--detail`.

Example:

```shell
root@kadalu-dev:/src/mgr# ./bin/kadalu rebalance status dev/vol1 
Name                       : dev/vol1
Type                       : Distribute
ID                         : 2111a5bd-7687-4384-82d8-c46f70dd9985
Progress                   : 66.67 %
Estimate Seconds           : 0
Scanned                    : 13.5MiB / 13.5MiB

Volume vol1 Rebalance Status            : partial
Total Number of Rebalance Process       : 6
Number of Completed Rebalance Process   : 4
Number of Failed Rebalance Process      : 0
```
```shell
root@kadalu-dev:/src/mgr# ./bin/kadalu rebalance status dev/vol1 --detail
Name                                    : dev/vol1
Type                                    : Distribute
ID                                      : 2111a5bd-7687-4384-82d8-c46f70dd9985
Distribute group 1 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s1
     Status                             : not started
     Progress                           : 0 %
     Scanned                            : 0B / 0B
     Duration Seconds                   : 0
     Estimate Seconds                   : 0

Distribute group 2 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s2
     Status                             : complete
     Progress                           : 100 %
     Scanned                            : 39.8MiB / 39.8MiB
     Duration Seconds                   : 2
     Estimate Seconds                   : 0

Distribute group 3 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s3
     Status                             : complete
     Progress                           : 100 %
     Scanned                            : 39.5MiB / 39.5MiB
     Duration Seconds                   : 2
     Estimate Seconds                   : 0

Distribute group 4 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s1_e
     Status                             : not started
     Progress                           : 0 %
     Scanned                            : 0B / 0B
     Duration Seconds                   : 0
     Estimate Seconds                   : 0

Distribute group 5 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s2_e
     Status                             : complete
     Progress                           : 100 %
     Scanned                            : 1.09MiB / 1.09MiB
     Duration Seconds                   : 0
     Estimate Seconds                   : 0

Distribute group 6 
    Storage unit 1                      : kadalu-dev:/exports/vol1/s3_e
     Status                             : complete
     Progress                           : 100 %
     Scanned                            : 1.09MiB / 1.09MiB
     Duration Seconds                   : 0
     Estimate Seconds                   : 0

Volume vol1 Rebalance Status            : partial
Total Number of Rebalance Process       : 6
Number of Completed Rebalance Process   : 4
Number of Failed Rebalance Process      : 0
```


Updates: https://github.com/kadalu/rfcs/pull/26
Signed-off-by: Shree Vatsa N <vatsa@kadalu.tech>